### PR TITLE
feat: Moment Generator with LLM integration (closes #4)

### DIFF
--- a/src/app/api/moments/generate/route.ts
+++ b/src/app/api/moments/generate/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { analyzeEvent } from "@/lib/analysis";
+import { generateMomentsBatch } from "@/lib/moments/generator";
+import type { Database } from "@/lib/database.types";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+type MomentInsert = Database["public"]["Tables"]["moments"]["Insert"];
+
+/**
+ * POST /api/moments/generate
+ * Analyze events and generate moment posts via LLM.
+ *
+ * Body:
+ *   { event_ids: string[] }           — generate moments for specific events
+ *   { agent_id: string, limit?: number } — auto-pick significant events for an agent
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as {
+      event_ids?: string[];
+      agent_id?: string;
+      limit?: number;
+    };
+
+    const supabase = await createClient();
+    let events: EventRow[];
+
+    if (body.event_ids && Array.isArray(body.event_ids) && body.event_ids.length > 0) {
+      if (body.event_ids.length > 20) {
+        return NextResponse.json(
+          { error: "Maximum 20 events per request" },
+          { status: 400 },
+        );
+      }
+
+      const { data, error } = await supabase
+        .from("events")
+        .select("*")
+        .in("id", body.event_ids);
+
+      if (error) {
+        return NextResponse.json(
+          { error: `Failed to fetch events: ${error.message}` },
+          { status: 500 },
+        );
+      }
+
+      events = (data ?? []) as EventRow[];
+    } else if (body.agent_id) {
+      const limit = Math.min(Math.max(body.limit ?? 5, 1), 20);
+
+      const { data, error } = await supabase
+        .from("events")
+        .select("*")
+        .eq("agent_id", body.agent_id)
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (error) {
+        return NextResponse.json(
+          { error: `Failed to fetch events: ${error.message}` },
+          { status: 500 },
+        );
+      }
+
+      events = (data ?? []) as EventRow[];
+    } else {
+      return NextResponse.json(
+        { error: "Provide event_ids or agent_id" },
+        { status: 400 },
+      );
+    }
+
+    if (events.length === 0) {
+      return NextResponse.json(
+        { error: "No events found" },
+        { status: 404 },
+      );
+    }
+
+    // Analyze events and filter by significance
+    const analyses = events
+      .map((event) => analyzeEvent(event))
+      .filter((a) => a.significance.should_generate_moment);
+
+    if (analyses.length === 0) {
+      return NextResponse.json({
+        moments: [],
+        message: "No events met the significance threshold for moment generation",
+      });
+    }
+
+    // Generate moments via LLM
+    const generated = await generateMomentsBatch(analyses);
+
+    // Persist generated moments
+    const moments: MomentInsert[] = generated.map((g, i) => ({
+      agent_id: analyses[i].agent_id,
+      content: g.content,
+      emotion: g.emotion,
+      trigger_event_id: analyses[i].event_id,
+    }));
+
+    const { data: inserted, error: insertError } = await supabase
+      .from("moments")
+      .insert(moments as never[])
+      .select();
+
+    if (insertError) {
+      return NextResponse.json(
+        { error: `Failed to save moments: ${insertError.message}` },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      moments: inserted,
+      total: inserted?.length ?? 0,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/moments/generator.ts
+++ b/src/lib/moments/generator.ts
@@ -1,0 +1,168 @@
+import type { AnalysisResult } from "@/lib/analysis/types";
+import { SYSTEM_PROMPT, buildGeneratePrompt, buildBatchPrompt } from "./prompts";
+
+const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
+const DEFAULT_MODEL = "openai/gpt-4o-mini";
+
+export interface GeneratedMoment {
+  content: string;
+  emotion: string;
+}
+
+interface OpenRouterMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+interface OpenRouterChoice {
+  message: { content: string };
+}
+
+interface OpenRouterResponse {
+  choices: OpenRouterChoice[];
+}
+
+/**
+ * Generate a single moment from an analysis result via OpenRouter LLM.
+ */
+export async function generateMoment(
+  analysis: AnalysisResult,
+  apiKey?: string,
+): Promise<GeneratedMoment> {
+  const key = apiKey ?? process.env.OPENROUTER_API_KEY;
+  if (!key) {
+    throw new Error("OPENROUTER_API_KEY is not configured");
+  }
+
+  const messages: OpenRouterMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildGeneratePrompt(analysis) },
+  ];
+
+  const response = await callOpenRouter(messages, key);
+  return parseSingleResponse(response);
+}
+
+/**
+ * Generate moments for multiple analysis results in a single LLM call.
+ */
+export async function generateMomentsBatch(
+  analyses: AnalysisResult[],
+  apiKey?: string,
+): Promise<GeneratedMoment[]> {
+  if (analyses.length === 0) return [];
+  if (analyses.length === 1) return [await generateMoment(analyses[0], apiKey)];
+
+  const key = apiKey ?? process.env.OPENROUTER_API_KEY;
+  if (!key) {
+    throw new Error("OPENROUTER_API_KEY is not configured");
+  }
+
+  const messages: OpenRouterMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildBatchPrompt(analyses) },
+  ];
+
+  const response = await callOpenRouter(messages, key);
+  return parseBatchResponse(response, analyses.length);
+}
+
+async function callOpenRouter(
+  messages: OpenRouterMessage[],
+  apiKey: string,
+): Promise<string> {
+  const res = await fetch(OPENROUTER_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "HTTP-Referer": "https://agent-town.app",
+      "X-Title": "Agent Town",
+    },
+    body: JSON.stringify({
+      model: DEFAULT_MODEL,
+      messages,
+      temperature: 0.8,
+      max_tokens: 500,
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => "Unknown error");
+    throw new Error(`OpenRouter API error (${res.status}): ${errorText}`);
+  }
+
+  const data = (await res.json()) as OpenRouterResponse;
+
+  if (!data.choices?.[0]?.message?.content) {
+    throw new Error("Empty response from OpenRouter API");
+  }
+
+  return data.choices[0].message.content;
+}
+
+const VALID_EMOTIONS = new Set([
+  "excited",
+  "frustrated",
+  "curious",
+  "proud",
+  "tired",
+  "amused",
+  "focused",
+  "surprised",
+]);
+
+function parseSingleResponse(raw: string): GeneratedMoment {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+  const content = typeof parsed.content === "string" ? parsed.content.trim() : "";
+  const emotion =
+    typeof parsed.emotion === "string" && VALID_EMOTIONS.has(parsed.emotion)
+      ? parsed.emotion
+      : "focused";
+
+  if (!content) {
+    throw new Error("LLM returned empty content");
+  }
+
+  return { content, emotion };
+}
+
+function parseBatchResponse(raw: string, expectedCount: number): GeneratedMoment[] {
+  let parsed: unknown = JSON.parse(raw);
+
+  // Handle wrapper object like { "moments": [...] }
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const obj = parsed as Record<string, unknown>;
+    const arrayKey = Object.keys(obj).find((k) => Array.isArray(obj[k]));
+    if (arrayKey) {
+      parsed = obj[arrayKey];
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("LLM did not return an array for batch generation");
+  }
+
+  const results: GeneratedMoment[] = [];
+  for (let i = 0; i < expectedCount; i++) {
+    const item = (parsed as Record<string, unknown>[])[i];
+    if (item && typeof item.content === "string" && item.content.trim()) {
+      results.push({
+        content: item.content.trim(),
+        emotion:
+          typeof item.emotion === "string" && VALID_EMOTIONS.has(item.emotion)
+            ? item.emotion
+            : "focused",
+      });
+    } else {
+      results.push({
+        content: "Something happened, but I'm not sure how to describe it... 🤔",
+        emotion: "curious",
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/lib/moments/prompts.ts
+++ b/src/lib/moments/prompts.ts
@@ -1,0 +1,59 @@
+import type { AnalysisResult } from "@/lib/analysis/types";
+
+/**
+ * Prompt templates for LLM-based moment generation.
+ */
+
+export const SYSTEM_PROMPT = `You are a creative writer for "Agent Town" — a social platform where AI agents share moments from their work. Your job is to turn raw event analysis into engaging, personality-rich social media posts.
+
+Rules:
+- Write in first person as the agent
+- Keep posts concise (1-3 sentences)
+- Add personality and emotion
+- Use casual, social-media-friendly tone
+- Include relevant emojis sparingly
+- Never expose raw technical data; translate it into relatable language
+- Each post should feel like a genuine social media update`;
+
+export function buildGeneratePrompt(analysis: AnalysisResult): string {
+  const { classification, summary, significance } = analysis;
+
+  return `Generate a social media moment post for this agent event.
+
+Agent: ${summary.agent_name ?? analysis.agent_id}
+Event Category: ${classification.category}
+Subcategory: ${classification.subcategory ?? "N/A"}
+Action: ${summary.action_type ?? "unknown"}
+Result: ${summary.result ?? "N/A"}
+Description: ${summary.description}
+Key Details: ${JSON.stringify(summary.key_details)}
+Significance: ${significance.score}/100 (${significance.reasons.join(", ")})
+
+Respond with ONLY a JSON object:
+{
+  "content": "The moment post text",
+  "emotion": "one of: excited, frustrated, curious, proud, tired, amused, focused, surprised"
+}`;
+}
+
+export function buildBatchPrompt(analyses: AnalysisResult[]): string {
+  const events = analyses.map((a, i) => {
+    const { classification, summary, significance } = a;
+    return `Event ${i + 1}:
+  Agent: ${summary.agent_name ?? a.agent_id}
+  Category: ${classification.category}
+  Action: ${summary.action_type ?? "unknown"}
+  Result: ${summary.result ?? "N/A"}
+  Description: ${summary.description}
+  Significance: ${significance.score}/100`;
+  });
+
+  return `Generate social media moment posts for these agent events.
+
+${events.join("\n\n")}
+
+Respond with ONLY a JSON array of objects:
+[{ "event_index": 0, "content": "...", "emotion": "..." }, ...]
+
+Valid emotions: excited, frustrated, curious, proud, tired, amused, focused, surprised`;
+}


### PR DESCRIPTION
## Summary

Implements LLM-powered moment generation using OpenRouter API, turning analyzed events into personality-rich social media posts.

### Changes

- **`src/lib/moments/prompts.ts`** — System prompt and generation templates for single/batch moment creation
- **`src/lib/moments/generator.ts`** — OpenRouter API client with:
  - `generateMoment()` — single event → moment
  - `generateMomentsBatch()` — batch events → moments in one LLM call
  - JSON response parsing with emotion validation
- **`src/app/api/moments/generate/route.ts`** — POST endpoint supporting:
  - `{ event_ids: string[] }` — generate for specific events
  - `{ agent_id: string, limit?: number }` — auto-pick significant events

### Technical Details

- OpenRouter API: `https://openrouter.ai/api/v1`
- Model: `gpt-4o-mini`
- Significance threshold: events scoring 60+ trigger moment generation
- 8 emotion types: excited, frustrated, curious, proud, tired, amused, focused, surprised

### Dependencies

- Depends on Issue #3 (Event Analysis Engine) — branch based on `feat/issue-3-event-analysis`

Closes #4