### PR TITLE
feat: pixel-art status panel with agent cards and polling (closes #5)

### DIFF
--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/lib/database.types";
+import type { AgentStatus } from "@/lib/types";
+
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const now = new Date();
+    const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+    const thirtyMinAgo = new Date(now.getTime() - 30 * 60 * 1000).toISOString();
+    const twentyFourHAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    // Get all events in last 24h
+    const { data: allEventsRaw, error } = await supabase
+      .from("events")
+      .select("agent_id, event_type, created_at")
+      .gte("created_at", twentyFourHAgo)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: "Failed to fetch agents" }, { status: 500 });
+    }
+
+    const events = (allEventsRaw ?? []) as Pick<EventRow, "agent_id" | "event_type" | "created_at">[];
+
+    // Group by agent
+    const agentMap = new Map<
+      string,
+      { lastAt: string; lastType: string; count: number }
+    >();
+
+    for (const ev of events) {
+      const existing = agentMap.get(ev.agent_id);
+      if (!existing) {
+        agentMap.set(ev.agent_id, {
+          lastAt: ev.created_at,
+          lastType: ev.event_type,
+          count: 1,
+        });
+      } else {
+        existing.count++;
+      }
+    }
+
+    // Also check for agents with older events (not in 24h window)
+    const { data: olderAgentsRaw } = await supabase
+      .from("events")
+      .select("agent_id")
+      .lt("created_at", twentyFourHAgo);
+
+    const olderAgents = (olderAgentsRaw ?? []) as Pick<EventRow, "agent_id">[];
+    for (const ev of olderAgents) {
+      if (!agentMap.has(ev.agent_id)) {
+        agentMap.set(ev.agent_id, {
+          lastAt: "",
+          lastType: "",
+          count: 0,
+        });
+      }
+    }
+
+    const agents: AgentStatus[] = [];
+
+    for (const [agentId, info] of agentMap) {
+      let status: "online" | "idle" | "offline" = "offline";
+      if (info.lastAt && info.lastAt >= fiveMinAgo) {
+        status = "online";
+      } else if (info.lastAt && info.lastAt >= thirtyMinAgo) {
+        status = "idle";
+      }
+
+      agents.push({
+        agent_id: agentId,
+        status,
+        last_event_at: info.lastAt || null,
+        event_count_24h: info.count,
+        last_event_type: info.lastType || null,
+      });
+    }
+
+    // Sort: online first, then idle, then offline
+    const statusOrder = { online: 0, idle: 1, offline: 2 };
+    agents.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+    return NextResponse.json(agents);
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,3 +107,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .font-pixel {
+    font-family: var(--font-pixel), monospace;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Press_Start_2P } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -9,6 +9,12 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const pressStart2P = Press_Start_2P({
+  weight: "400",
+  variable: "--font-pixel",
   subsets: ["latin"],
 });
 
@@ -24,7 +30,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} ${pressStart2P.variable} antialiased`}>
         {children}
       </body>
     </html>

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,57 @@
+import { StatusGrid } from "@/components/status/StatusGrid";
+
+export const metadata = {
+  title: "Status Panel | Agent Town",
+  description: "Monitor your AI agents in real-time",
+};
+
+export default function StatusPage() {
+  return (
+    <main className="min-h-screen bg-[#000000]">
+      {/* Header */}
+      <header className="border-b-4 border-[#5f574f] bg-[#1d2b53] px-4 py-6 sm:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl" role="img" aria-label="Town">
+              🏘️
+            </span>
+            <div>
+              <h1 className="font-pixel text-lg text-[#fff1e8] sm:text-xl">
+                AGENT TOWN
+              </h1>
+              <p className="font-pixel text-[10px] text-[#c2c3c7]">
+                STATUS PANEL
+              </p>
+            </div>
+          </div>
+          <nav className="mt-4 flex gap-4" aria-label="Main navigation">
+            <a
+              href="/"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              HOME
+            </a>
+            <a
+              href="/status"
+              className="font-pixel text-[10px] text-[#ffa300] underline underline-offset-4"
+              aria-current="page"
+            >
+              STATUS
+            </a>
+            <a
+              href="/feed"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              FEED
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-8">
+        <StatusGrid />
+      </div>
+    </main>
+  );
+}

--- a/src/components/status/AgentCard.tsx
+++ b/src/components/status/AgentCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { AgentAvatar } from "@/components/feed/AgentAvatar";
+import { StatusBadge } from "./StatusBadge";
+import type { AgentStatus } from "@/lib/types";
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const date = new Date(dateStr).getTime();
+  const diff = now - date;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+const EVENT_TYPE_ICONS: Record<string, string> = {
+  "file.create": "📄",
+  "file.modify": "✏️",
+  "file.delete": "🗑️",
+  "git.commit": "📦",
+  "git.push": "🚀",
+  "shell.command": "💻",
+  "process.start": "▶️",
+  "process.end": "⏹️",
+};
+
+interface AgentCardProps {
+  agent: AgentStatus;
+  className?: string;
+}
+
+export function AgentCard({ agent, className }: AgentCardProps) {
+  const borderColor =
+    agent.status === "online"
+      ? "border-[#00e436]"
+      : agent.status === "idle"
+        ? "border-[#ffec27]"
+        : "border-[#5f574f]";
+
+  const bgColor =
+    agent.status === "online"
+      ? "bg-[#1d2b53]"
+      : agent.status === "idle"
+        ? "bg-[#1d2b53]/80"
+        : "bg-[#1d2b53]/50";
+
+  const eventIcon = agent.last_event_type
+    ? EVENT_TYPE_ICONS[agent.last_event_type] || "⚡"
+    : null;
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-none border-4 p-4 transition-all",
+        borderColor,
+        bgColor,
+        "shadow-[4px_4px_0px_0px_rgba(0,0,0,0.5)]",
+        "hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,0.5)]",
+        "hover:-translate-x-0.5 hover:-translate-y-0.5",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-3">
+          <AgentAvatar agentId={agent.agent_id} size="lg" />
+          <div className="min-w-0">
+            <h3 className="truncate font-pixel text-sm text-[#fff1e8]">
+              {agent.agent_id}
+            </h3>
+            <StatusBadge status={agent.status} className="mt-1" />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-2 border-t-2 border-[#5f574f] pt-3">
+        {agent.last_event_at && (
+          <div className="flex items-center justify-between">
+            <span className="font-pixel text-[10px] text-[#c2c3c7]">LAST SEEN</span>
+            <span className="font-pixel text-[10px] text-[#fff1e8]">
+              {formatRelativeTime(agent.last_event_at)}
+            </span>
+          </div>
+        )}
+
+        {agent.last_event_type && (
+          <div className="flex items-center justify-between">
+            <span className="font-pixel text-[10px] text-[#c2c3c7]">ACTIVITY</span>
+            <span className="font-pixel text-[10px] text-[#fff1e8]">
+              {eventIcon} {agent.last_event_type}
+            </span>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between">
+          <span className="font-pixel text-[10px] text-[#c2c3c7]">24H EVENTS</span>
+          <span className="font-pixel text-[10px] text-[#ffa300]">
+            {agent.event_count_24h}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/status/StatusBadge.tsx
+++ b/src/components/status/StatusBadge.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface StatusBadgeProps {
+  status: "online" | "idle" | "offline";
+  className?: string;
+}
+
+const STATUS_CONFIG = {
+  online: {
+    label: "ONLINE",
+    dotClass: "bg-[#00e436]", // Pico-8 green
+    textClass: "text-[#00e436]",
+    borderClass: "border-[#00e436]",
+  },
+  idle: {
+    label: "IDLE",
+    dotClass: "bg-[#ffec27]", // Pico-8 yellow
+    textClass: "text-[#ffec27]",
+    borderClass: "border-[#ffec27]",
+  },
+  offline: {
+    label: "OFFLINE",
+    dotClass: "bg-[#83769c]", // Pico-8 lavender
+    textClass: "text-[#83769c]",
+    borderClass: "border-[#83769c]",
+  },
+};
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-none border-2 px-2 py-0.5",
+        config.borderClass,
+        className,
+      )}
+      role="status"
+      aria-label={`Agent is ${status}`}
+    >
+      <span
+        className={cn("h-2 w-2 rounded-none", config.dotClass, status === "online" && "animate-pulse")}
+        aria-hidden="true"
+      />
+      <span
+        className={cn("font-pixel text-[10px] uppercase tracking-wider", config.textClass)}
+      >
+        {config.label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/status/StatusGrid.tsx
+++ b/src/components/status/StatusGrid.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { AgentCard } from "./AgentCard";
+import type { AgentStatus } from "@/lib/types";
+
+const POLL_INTERVAL = 7000;
+
+export function StatusGrid() {
+  const [agents, setAgents] = useState<AgentStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAgents = useCallback(async () => {
+    try {
+      const res = await fetch("/api/agents");
+      if (!res.ok) throw new Error("Failed to fetch agents");
+      const data: AgentStatus[] = await res.json();
+      setAgents(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAgents().finally(() => setLoading(false));
+  }, [fetchAgents]);
+
+  useEffect(() => {
+    const interval = setInterval(fetchAgents, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchAgents]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16" role="status" aria-label="Loading">
+        <div className="font-pixel text-sm text-[#c2c3c7] animate-pulse">
+          LOADING AGENTS...
+        </div>
+      </div>
+    );
+  }
+
+  if (error && agents.length === 0) {
+    return (
+      <div className="py-16 text-center" role="alert">
+        <p className="font-pixel text-sm text-[#ff004d]">{error}</p>
+        <button
+          onClick={() => {
+            setLoading(true);
+            setError(null);
+            fetchAgents().finally(() => setLoading(false));
+          }}
+          className="mt-4 rounded-none border-2 border-[#ff004d] px-4 py-2 font-pixel text-xs text-[#ff004d] hover:bg-[#ff004d] hover:text-[#000000] transition-colors"
+        >
+          RETRY
+        </button>
+      </div>
+    );
+  }
+
+  if (agents.length === 0) {
+    return (
+      <div className="py-16 text-center">
+        <p className="font-pixel text-sm text-[#c2c3c7]">
+          NO AGENTS FOUND
+        </p>
+        <p className="mt-2 font-pixel text-[10px] text-[#83769c]">
+          Start the watcher to see agents appear here
+        </p>
+      </div>
+    );
+  }
+
+  const onlineCount = agents.filter((a) => a.status === "online").length;
+  const idleCount = agents.filter((a) => a.status === "idle").length;
+  const offlineCount = agents.filter((a) => a.status === "offline").length;
+
+  return (
+    <div>
+      {/* Summary bar */}
+      <div className="mb-6 flex flex-wrap items-center gap-4 rounded-none border-2 border-[#5f574f] bg-[#1d2b53]/60 px-4 py-3">
+        <span className="font-pixel text-[10px] text-[#c2c3c7]">
+          TOTAL: <span className="text-[#fff1e8]">{agents.length}</span>
+        </span>
+        <span className="font-pixel text-[10px] text-[#00e436]">
+          ONLINE: {onlineCount}
+        </span>
+        <span className="font-pixel text-[10px] text-[#ffec27]">
+          IDLE: {idleCount}
+        </span>
+        <span className="font-pixel text-[10px] text-[#83769c]">
+          OFFLINE: {offlineCount}
+        </span>
+      </div>
+
+      {/* Agent grid */}
+      <div
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        role="list"
+        aria-label="Agent status cards"
+      >
+        {agents.map((agent) => (
+          <div key={agent.agent_id} role="listitem">
+            <AgentCard agent={agent} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,5 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
-import type { Database } from "./database.types";
+import type { Database } from "../database.types";
 
 export function createClient() {
   return createBrowserClient<Database>(

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -14,7 +14,7 @@ export async function updateSession(request: NextRequest) {
         getAll() {
           return request.cookies.getAll();
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -13,7 +13,7 @@ export async function createClient() {
         getAll() {
           return cookieStore.getAll();
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface AgentStatus {
+  agent_id: string;
+  status: "online" | "idle" | "offline";
+  last_event_at: string | null;
+  event_count_24h: number;
+  last_event_type: string | null;
+}


### PR DESCRIPTION
## Summary
Implements the Status Panel page (Issue #5) with pixel-art aesthetic.

### New Files
- `src/app/status/page.tsx` — Status panel page with Pico-8 themed header and nav
- `src/components/status/AgentCard.tsx` — Pixel-art agent card with status, last seen, activity
- `src/components/status/StatusGrid.tsx` — Responsive grid with 7s polling and summary bar
- `src/components/status/StatusBadge.tsx` — Online/idle/offline badge with animated pulse
- `src/app/api/agents/route.ts` — API to aggregate events and infer agent status
- `src/lib/types.ts` — Shared AgentStatus type

### Design
- Press Start 2P pixel font via next/font/google
- Pico-8 color palette (#1d2b53, #fff1e8, #00e436, #ffa300, etc.)
- Square borders, hard shadows, no border-radius
- Online = event in last 5min, Idle = last 30min, Offline = beyond

### Bug Fixes
- Fix supabase client.ts import path (./database.types → ../database.types)
- Fix implicit any types in supabase middleware.ts and server.ts

Closes #5