### PR TITLE
feat: Town map expansion with day/night cycle (closes #23)

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { StatusGrid } from '@/components/status/StatusGrid';
+
+const TownCanvas = dynamic(
+  () => import('@/components/game/TownCanvas'),
+  { ssr: false }
+);
+
+type ViewMode = 'town' | 'grid';
+
+export default function TownPage() {
+  const [viewMode, setViewMode] = useState<ViewMode>('town');
+
+  return (
+    <main className="min-h-screen bg-[#000000]">
+      {/* Header */}
+      <header className="border-b-4 border-[#5f574f] bg-[#1d2b53] px-4 py-6 sm:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <span className="text-2xl" role="img" aria-label="Town">
+                🏘️
+              </span>
+              <div>
+                <h1 className="font-pixel text-lg text-[#fff1e8] sm:text-xl">
+                  AGENT TOWN
+                </h1>
+                <p className="font-pixel text-[10px] text-[#c2c3c7]">
+                  TOWN VIEW
+                </p>
+              </div>
+            </div>
+
+            {/* View Toggle */}
+            <div className="flex gap-2">
+              <button
+                onClick={() => setViewMode('town')}
+                className={`font-pixel text-[10px] px-3 py-2 border-2 transition-colors ${
+                  viewMode === 'town'
+                    ? 'border-[#ffa300] text-[#ffa300] bg-[#ffa300]/10'
+                    : 'border-[#5f574f] text-[#83769c] hover:text-[#fff1e8] hover:border-[#fff1e8]'
+                }`}
+                aria-pressed={viewMode === 'town'}
+              >
+                TOWN
+              </button>
+              <button
+                onClick={() => setViewMode('grid')}
+                className={`font-pixel text-[10px] px-3 py-2 border-2 transition-colors ${
+                  viewMode === 'grid'
+                    ? 'border-[#ffa300] text-[#ffa300] bg-[#ffa300]/10'
+                    : 'border-[#5f574f] text-[#83769c] hover:text-[#fff1e8] hover:border-[#fff1e8]'
+                }`}
+                aria-pressed={viewMode === 'grid'}
+              >
+                GRID
+              </button>
+            </div>
+          </div>
+
+          <nav className="mt-4 flex gap-4" aria-label="Main navigation">
+            <a
+              href="/"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              HOME
+            </a>
+            <a
+              href="/status"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              STATUS
+            </a>
+            <a
+              href="/office"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              OFFICE
+            </a>
+            <a
+              href="/town"
+              className="font-pixel text-[10px] text-[#ffa300] underline underline-offset-4"
+              aria-current="page"
+            >
+              TOWN
+            </a>
+            <a
+              href="/feed"
+              className="font-pixel text-[10px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+            >
+              FEED
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-8">
+        {viewMode === 'town' ? (
+          <div className="flex flex-col">
+            <div className="border-4 border-[#5f574f] rounded-none overflow-hidden bg-[#1d2b53] p-4">
+              <TownCanvas />
+            </div>
+            <p className="text-[#83769c] mt-4 font-pixel text-[10px] text-center">
+              CLICK ON AN AGENT TO VIEW DETAILS • USE NUMBER KEYS 1-5 TO NAVIGATE • RIGHT-CLICK DRAG TO PAN
+            </p>
+          </div>
+        ) : (
+          <StatusGrid />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/game/Minimap.tsx
+++ b/src/components/game/Minimap.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface MinimapProps {
+  mapWidth: number;
+  mapHeight: number;
+  viewportX: number;
+  viewportY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  areas: Array<{
+    name: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    color: string;
+  }>;
+  onAreaClick?: (areaName: string) => void;
+}
+
+export function Minimap({
+  mapWidth,
+  mapHeight,
+  viewportX,
+  viewportY,
+  viewportWidth,
+  viewportHeight,
+  areas,
+  onAreaClick,
+}: MinimapProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const minimapWidth = 160;
+  const minimapHeight = 120;
+  const scaleX = minimapWidth / mapWidth;
+  const scaleY = minimapHeight / mapHeight;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Clear
+    ctx.fillStyle = '#1d2b53';
+    ctx.fillRect(0, 0, minimapWidth, minimapHeight);
+
+    // Draw areas
+    areas.forEach((area) => {
+      ctx.fillStyle = area.color;
+      ctx.fillRect(
+        area.x * scaleX,
+        area.y * scaleY,
+        area.width * scaleX,
+        area.height * scaleY
+      );
+      
+      // Area border
+      ctx.strokeStyle = '#5f574f';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(
+        area.x * scaleX,
+        area.y * scaleY,
+        area.width * scaleX,
+        area.height * scaleY
+      );
+    });
+
+    // Draw viewport indicator
+    ctx.strokeStyle = '#fff1e8';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(
+      viewportX * scaleX,
+      viewportY * scaleY,
+      viewportWidth * scaleX,
+      viewportHeight * scaleY
+    );
+  }, [viewportX, viewportY, viewportWidth, viewportHeight, areas, scaleX, scaleY]);
+
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!onAreaClick) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / scaleX;
+    const y = (e.clientY - rect.top) / scaleY;
+
+    // Find clicked area
+    for (const area of areas) {
+      if (
+        x >= area.x &&
+        x < area.x + area.width &&
+        y >= area.y &&
+        y < area.y + area.height
+      ) {
+        onAreaClick(area.name);
+        break;
+      }
+    }
+  };
+
+  return (
+    <div className="border-2 border-[#5f574f] bg-[#1d2b53]">
+      <div className="border-b border-[#5f574f] px-2 py-1">
+        <span className="font-pixel text-[8px] text-[#c2c3c7]">MAP</span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={minimapWidth}
+        height={minimapHeight}
+        onClick={handleClick}
+        className="cursor-pointer"
+        style={{ display: 'block' }}
+      />
+      {/* Area labels */}
+      <div className="px-2 py-1 flex flex-wrap gap-2">
+        {areas.map((area) => (
+          <button
+            key={area.name}
+            onClick={() => onAreaClick?.(area.name)}
+            className="font-pixel text-[8px] text-[#83769c] hover:text-[#fff1e8] transition-colors"
+          >
+            {area.name.toUpperCase()}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/TownCanvas.tsx
+++ b/src/components/game/TownCanvas.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import Phaser from 'phaser';
+import type { AgentStatus } from '@/lib/types';
+import { TOWN_MAP, TownArea } from '@/game/maps/town-map';
+
+// Inline AgentDetailModal to avoid import issues
+function AgentDetailModal({ agent, onClose }: { agent: AgentStatus | null; onClose: () => void }) {
+  if (!agent) return null;
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'online': return '#00e436';
+      case 'idle': return '#ffec27';
+      default: return '#83769c';
+    }
+  };
+
+  const formatTimeAgo = (dateStr: string | null) => {
+    if (!dateStr) return 'Never';
+    const diffMs = Date.now() - new Date(dateStr).getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 60) return `${diffMin}m ago`;
+    return `${Math.floor(diffMin / 60)}h ago`;
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/70" />
+      <div className="relative w-full max-w-sm mx-4" onClick={(e) => e.stopPropagation()}>
+        <div className="border-4 border-[#5f574f] bg-[#1d2b53]">
+          <div className="border-b-2 border-[#5f574f] bg-[#29366f] px-4 py-3 flex justify-between">
+            <h2 className="font-pixel text-sm text-[#fff1e8] truncate">{agent.agent_id}</h2>
+            <button onClick={onClose} className="font-pixel text-xs text-[#ff004d]">[X]</button>
+          </div>
+          <div className="p-4 space-y-3">
+            <div className="flex items-center gap-3">
+              <span className="font-pixel text-[10px] text-[#c2c3c7]">STATUS:</span>
+              <span className="font-pixel text-xs" style={{ color: getStatusColor(agent.status) }}>
+                {agent.status.toUpperCase()}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="font-pixel text-[10px] text-[#c2c3c7]">LAST:</span>
+              <span className="font-pixel text-xs text-[#fff1e8]">{formatTimeAgo(agent.last_event_at)}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="font-pixel text-[10px] text-[#c2c3c7]">24H:</span>
+              <span className="font-pixel text-xs text-[#29adff]">{agent.event_count_24h}</span>
+            </div>
+          </div>
+          <div className="border-t-2 border-[#5f574f] px-4 py-3">
+            <button onClick={onClose} className="w-full font-pixel text-xs text-[#c2c3c7] border-2 border-[#5f574f] py-2">
+              CLOSE
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TownCanvasProps {
+  className?: string;
+}
+
+const AREA_COLORS: Record<string, string> = {
+  office: '#1d2b53',
+  park: '#008751',
+  residential: '#ab5236',
+  coffeeShop: '#7e2553',
+  store: '#5f574f',
+};
+
+export default function TownCanvas({ className }: TownCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<AgentStatus | null>(null);
+  const [currentArea, setCurrentArea] = useState<TownArea>('office');
+
+  const handleAgentClick = useCallback(async (agentId: string) => {
+    try {
+      const res = await fetch('/api/agents');
+      if (!res.ok) return;
+      const agents: AgentStatus[] = await res.json();
+      const agent = agents.find(a => a.agent_id === agentId);
+      if (agent) {
+        setSelectedAgent(agent);
+      }
+    } catch (err) {
+      console.error('Failed to fetch agent details:', err);
+    }
+  }, []);
+
+  const handleAreaChange = useCallback((area: TownArea) => {
+    setCurrentArea(area);
+  }, []);
+
+  const navigateToArea = useCallback((areaName: string) => {
+    const game = gameRef.current;
+    if (!game) return;
+    
+    const scene = game.scene.getScene('TownScene') as any;
+    if (scene && scene.navigateToArea) {
+      scene.navigateToArea(areaName as TownArea);
+    }
+  }, []);
+
+  useEffect(() => {
+    const initializeGame = async () => {
+      if (typeof window === 'undefined' || gameRef.current) return;
+
+      const { TownScene, setTownCallbacks } = await import('@/game/scenes/TownScene');
+      const Phaser = (await import('phaser')).default;
+      
+      // Set up callbacks
+      setTownCallbacks({
+        onAgentClick: handleAgentClick,
+        onAreaChange: handleAreaChange,
+      });
+      
+      const config: Phaser.Types.Core.GameConfig = {
+        type: Phaser.AUTO,
+        width: 800,
+        height: 600,
+        pixelArt: true,
+        roundPixels: true,
+        backgroundColor: '#1a1a2e',
+        parent: 'town-container',
+        scene: [TownScene],
+        scale: {
+          mode: Phaser.Scale.FIT,
+          autoCenter: Phaser.Scale.CENTER_BOTH,
+        },
+      };
+
+      if (containerRef.current) {
+        gameRef.current = new Phaser.Game(config);
+      }
+
+      return () => {
+        setTownCallbacks({});
+        if (gameRef.current) {
+          gameRef.current.destroy(true);
+          gameRef.current = null;
+        }
+      };
+    };
+
+    const cleanup = initializeGame();
+
+    return () => {
+      cleanup.then((cleanupFn) => cleanupFn?.());
+    };
+  }, [handleAgentClick, handleAreaChange]);
+
+  return (
+    <div className="flex gap-4">
+      <div className="flex-1">
+        <div
+          id="town-container"
+          ref={containerRef}
+          className={className}
+          style={{
+            width: '100%',
+            maxWidth: '800px',
+            aspectRatio: '4/3',
+          }}
+        />
+        <div className="mt-2 flex gap-2 flex-wrap">
+          {Object.entries(TOWN_MAP.areas).map(([name, area]) => (
+            <button
+              key={name}
+              onClick={() => navigateToArea(name)}
+              className={`font-pixel text-[10px] px-3 py-2 border-2 transition-colors ${
+                currentArea === name
+                  ? 'border-[#ffa300] text-[#ffa300] bg-[#ffa300]/10'
+                  : 'border-[#5f574f] text-[#83769c] hover:text-[#fff1e8] hover:border-[#fff1e8]'
+              }`}
+            >
+              {area.name.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+      
+      
+      {/* Minimap - inline simple version */}
+      <div className="hidden lg:block border-2 border-[#5f574f] bg-[#1d2b53] p-2">
+        <div className="font-pixel text-[8px] text-[#c2c3c7] mb-2">MAP</div>
+        <div className="flex flex-wrap gap-1">
+          {Object.entries(TOWN_MAP.areas).map(([name, area]) => (
+            <button
+              key={name}
+              onClick={() => navigateToArea(name)}
+              className="font-pixel text-[8px] text-[#83769c] hover:text-[#fff1e8]"
+              style={{ 
+                backgroundColor: AREA_COLORS[name],
+                padding: '4px 8px',
+              }}
+            >
+              {area.name.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <AgentDetailModal
+        agent={selectedAgent}
+        onClose={() => setSelectedAgent(null)}
+      />
+    </div>
+  );
+}

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { OfficeScene } from './scenes/OfficeScene';
+import { TownScene } from './scenes/TownScene';
 
 export const gameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -9,7 +10,7 @@ export const gameConfig: Phaser.Types.Core.GameConfig = {
   roundPixels: true,
   backgroundColor: '#1a1a2e',
   parent: 'game-container',
-  scene: [OfficeScene],
+  scene: [OfficeScene, TownScene],
   physics: {
     default: 'arcade',
     arcade: {

--- a/src/game/maps/town-map.ts
+++ b/src/game/maps/town-map.ts
@@ -1,0 +1,318 @@
+// Town tilemap data (40x30 tiles) - expanded from office
+// Includes: Office, Park, Residential, Coffee Shop, Store
+
+export const TOWN_MAP = {
+  width: 40,
+  height: 30,
+  tileWidth: 32,
+  tileHeight: 32,
+
+  // Area definitions for navigation
+  areas: {
+    office: { x: 0, y: 0, width: 20, height: 15, name: 'Office' },
+    park: { x: 20, y: 0, width: 20, height: 15, name: 'Park' },
+    residential: { x: 0, y: 15, width: 20, height: 15, name: 'Residential' },
+    coffeeShop: { x: 20, y: 15, width: 10, height: 15, name: 'Coffee Shop' },
+    store: { x: 30, y: 15, width: 10, height: 15, name: 'Store' },
+  },
+
+  layers: {
+    // Ground layer
+    ground: generateGroundLayer(),
+    // Furniture/objects layer
+    furniture: generateFurnitureLayer(),
+    // Collision layer
+    collision: generateCollisionLayer(),
+  },
+
+  // Named locations for spawning/navigation
+  locations: {
+    // Office area
+    officeEntrance: { x: 9, y: 13, area: 'office' },
+    coffeeArea: { x: 2, y: 11, area: 'office' },
+    meetingRoom: { x: 10, y: 10, area: 'office' },
+    workstations: [
+      { x: 2, y: 2, id: 'desk-1', area: 'office' },
+      { x: 6, y: 2, id: 'desk-2', area: 'office' },
+      { x: 2, y: 5, id: 'desk-3', area: 'office' },
+      { x: 6, y: 5, id: 'desk-4', area: 'office' },
+      { x: 2, y: 8, id: 'desk-5', area: 'office' },
+      { x: 6, y: 8, id: 'desk-6', area: 'office' },
+    ],
+    // Park area
+    parkBench1: { x: 25, y: 5, area: 'park' },
+    parkBench2: { x: 32, y: 8, area: 'park' },
+    fountain: { x: 28, y: 7, area: 'park' },
+    // Residential area
+    house1: { x: 3, y: 18, area: 'residential' },
+    house2: { x: 10, y: 18, area: 'residential' },
+    house3: { x: 3, y: 24, area: 'residential' },
+    // Coffee shop
+    coffeeCounter: { x: 24, y: 20, area: 'coffeeShop' },
+    coffeeSeating: { x: 22, y: 24, area: 'coffeeShop' },
+    // Store
+    storeCounter: { x: 34, y: 20, area: 'store' },
+  },
+};
+
+function generateGroundLayer(): number[][] {
+  const layer: number[][] = [];
+  
+  for (let y = 0; y < 30; y++) {
+    const row: number[] = [];
+    for (let x = 0; x < 40; x++) {
+      // Office area (0-19, 0-14)
+      if (x < 20 && y < 15) {
+        row.push(getOfficeFloor(x, y));
+      }
+      // Park area (20-39, 0-14)
+      else if (x >= 20 && y < 15) {
+        row.push(getParkFloor(x, y));
+      }
+      // Residential area (0-19, 15-29)
+      else if (x < 20 && y >= 15) {
+        row.push(getResidentialFloor(x, y));
+      }
+      // Coffee shop (20-29, 15-29)
+      else if (x >= 20 && x < 30 && y >= 15) {
+        row.push(getCoffeeShopFloor(x, y));
+      }
+      // Store (30-39, 15-29)
+      else {
+        row.push(getStoreFloor(x, y));
+      }
+    }
+    layer.push(row);
+  }
+  
+  return layer;
+}
+
+function getOfficeFloor(x: number, y: number): number {
+  // Meeting room carpet
+  if (x >= 10 && x <= 13 && y >= 9 && y <= 12) return 2;
+  // Checkerboard pattern
+  return (x + y) % 2 === 0 ? 0 : 1;
+}
+
+function getParkFloor(x: number, y: number): number {
+  // Grass (tile 3)
+  return 3;
+}
+
+function getResidentialFloor(x: number, y: number): number {
+  // Road
+  if (y === 15 || y === 22) return 4;
+  if (x === 8 || x === 15) return 4;
+  // Grass
+  return 3;
+}
+
+function getCoffeeShopFloor(x: number, y: number): number {
+  // Wooden floor (tile 5)
+  return 5;
+}
+
+function getStoreFloor(x: number, y: number): number {
+  // Tile floor (tile 6)
+  return 6;
+}
+
+function generateFurnitureLayer(): number[][] {
+  const layer: number[][] = [];
+  
+  for (let y = 0; y < 30; y++) {
+    const row: number[] = [];
+    for (let x = 0; x < 40; x++) {
+      row.push(getFurniture(x, y));
+    }
+    layer.push(row);
+  }
+  
+  return layer;
+}
+
+function getFurniture(x: number, y: number): number {
+  // Office walls
+  if (x < 20 && y < 15) {
+    if (y === 0) return 10; // Top wall
+    if (y === 14) return 11; // Bottom wall
+    if (x === 0) return 12; // Left wall
+    if (x === 19) return 13; // Right wall
+    // Office furniture
+    if (x === 2 && y === 2) return 20; // Desk
+    if (x === 3 && y === 2) return 28; // Computer
+    if (x === 2 && y === 3) return 24; // Chair
+    if (x === 6 && y === 2) return 20;
+    if (x === 7 && y === 2) return 28;
+    if (x === 6 && y === 3) return 24;
+    if (x === 2 && y === 5) return 20;
+    if (x === 3 && y === 5) return 28;
+    if (x === 2 && y === 6) return 24;
+    if (x === 6 && y === 5) return 20;
+    if (x === 7 && y === 5) return 28;
+    if (x === 6 && y === 6) return 24;
+    if (x === 2 && y === 8) return 20;
+    if (x === 3 && y === 8) return 28;
+    if (x === 2 && y === 9) return 24;
+    if (x === 6 && y === 8) return 20;
+    if (x === 7 && y === 8) return 28;
+    if (x === 6 && y === 9) return 24;
+    // Meeting table
+    if ((x === 10 || x === 11) && (y === 9 || y === 10)) return 50;
+    // Coffee area
+    if (x === 2 && y === 11) return 40;
+    if (x === 3 && y === 11) return 41;
+    if (x === 6 && y === 11) return 44;
+    // Whiteboard
+    if (x === 15 && y === 2) return 54;
+    // Door
+    if (x === 9 && y === 13) return 60;
+  }
+  
+  // Park furniture
+  if (x >= 20 && y < 15) {
+    // Park boundary
+    if (y === 0 || y === 14) return 70; // Fence
+    if (x === 20 || x === 39) return 71; // Fence vertical
+    // Trees
+    if ((x === 22 || x === 26 || x === 30 || x === 35) && y === 2) return 72;
+    if ((x === 24 || x === 33 || x === 37) && y === 12) return 72;
+    // Benches
+    if (x === 25 && y === 5) return 73;
+    if (x === 32 && y === 8) return 73;
+    // Fountain
+    if (x >= 27 && x <= 29 && y >= 6 && y <= 8) return 74;
+    // Flowers
+    if ((x === 23 || x === 31 || x === 36) && y === 4) return 75;
+  }
+  
+  // Residential
+  if (x < 20 && y >= 15) {
+    // Houses
+    if (x >= 2 && x <= 6 && y >= 17 && y <= 20) return 80; // House 1
+    if (x >= 9 && x <= 13 && y >= 17 && y <= 20) return 80; // House 2
+    if (x >= 2 && x <= 6 && y >= 23 && y <= 26) return 80; // House 3
+    // Street lamps
+    if ((x === 1 || x === 18) && (y === 16 || y === 23)) return 81;
+    // Mailboxes
+    if (x === 7 && y === 20) return 82;
+    if (x === 14 && y === 20) return 82;
+  }
+  
+  // Coffee shop
+  if (x >= 20 && x < 30 && y >= 15) {
+    // Walls
+    if (y === 15) return 10;
+    if (y === 29) return 11;
+    if (x === 20) return 12;
+    if (x === 29) return 13;
+    // Counter
+    if (x >= 23 && x <= 26 && y === 19) return 90;
+    // Coffee machine
+    if (x === 27 && y === 17) return 40;
+    // Tables
+    if ((x === 22 || x === 26) && y === 24) return 91;
+    // Chairs
+    if ((x === 21 || x === 23 || x === 25 || x === 27) && y === 24) return 24;
+    // Door
+    if (x === 24 && y === 15) return 60;
+  }
+  
+  // Store
+  if (x >= 30 && y >= 15) {
+    // Walls
+    if (y === 15) return 10;
+    if (y === 29) return 11;
+    if (x === 30) return 12;
+    if (x === 39) return 13;
+    // Counter
+    if (x >= 33 && x <= 36 && y === 19) return 92;
+    // Shelves
+    if ((x === 32 || x === 37) && (y === 22 || y === 25)) return 93;
+    // Door
+    if (x === 34 && y === 15) return 60;
+  }
+  
+  return -1;
+}
+
+function generateCollisionLayer(): number[][] {
+  const layer: number[][] = [];
+  
+  for (let y = 0; y < 30; y++) {
+    const row: number[] = [];
+    for (let x = 0; x < 40; x++) {
+      row.push(getCollision(x, y));
+    }
+    layer.push(row);
+  }
+  
+  return layer;
+}
+
+function getCollision(x: number, y: number): number {
+  // Office walls
+  if (x < 20 && y < 15) {
+    if (y === 0 || y === 14) return 1;
+    if (x === 0 || x === 19) return 1;
+    // Door is walkable
+    if (x === 9 && y === 13) return 0;
+    // Furniture collision
+    if ((x === 2 || x === 6) && (y === 2 || y === 5 || y === 8)) return 1;
+    if ((x === 3 || x === 7) && (y === 2 || y === 5 || y === 8)) return 1;
+    if ((x === 10 || x === 11) && (y === 9 || y === 10)) return 1;
+    if (x === 2 && y === 11) return 1;
+    if (x === 3 && y === 11) return 1;
+    if (x === 15 && y === 2) return 1;
+  }
+  
+  // Park
+  if (x >= 20 && y < 15) {
+    if (y === 0 || y === 14) return 1;
+    if (x === 20 || x === 39) return 1;
+    // Trees
+    if ((x === 22 || x === 26 || x === 30 || x === 35) && y === 2) return 1;
+    if ((x === 24 || x === 33 || x === 37) && y === 12) return 1;
+    // Fountain
+    if (x >= 27 && x <= 29 && y >= 6 && y <= 8) return 1;
+  }
+  
+  // Residential
+  if (x < 20 && y >= 15) {
+    // Houses
+    if (x >= 2 && x <= 6 && y >= 17 && y <= 20) return 1;
+    if (x >= 9 && x <= 13 && y >= 17 && y <= 20) return 1;
+    if (x >= 2 && x <= 6 && y >= 23 && y <= 26) return 1;
+    // Street lamps
+    if ((x === 1 || x === 18) && (y === 16 || y === 23)) return 1;
+  }
+  
+  // Coffee shop
+  if (x >= 20 && x < 30 && y >= 15) {
+    if (y === 15 && x !== 24) return 1;
+    if (y === 29) return 1;
+    if (x === 20 || x === 29) return 1;
+    // Counter
+    if (x >= 23 && x <= 26 && y === 19) return 1;
+    if (x === 27 && y === 17) return 1;
+    // Tables
+    if ((x === 22 || x === 26) && y === 24) return 1;
+  }
+  
+  // Store
+  if (x >= 30 && y >= 15) {
+    if (y === 15 && x !== 34) return 1;
+    if (y === 29) return 1;
+    if (x === 30 || x === 39) return 1;
+    // Counter
+    if (x >= 33 && x <= 36 && y === 19) return 1;
+    // Shelves
+    if ((x === 32 || x === 37) && (y === 22 || y === 25)) return 1;
+  }
+  
+  return 0;
+}
+
+export type TownArea = keyof typeof TOWN_MAP.areas;
+export type TownLocation = keyof typeof TOWN_MAP.locations;

--- a/src/game/scenes/TownScene.ts
+++ b/src/game/scenes/TownScene.ts
@@ -1,0 +1,530 @@
+import Phaser from 'phaser';
+import { TILE_SIZE } from '../tiles/tileset-generator';
+import { TOWN_MAP, TownArea } from '../maps/town-map';
+import { PICO8_COLORS } from '../tiles/palette';
+import { AgentSprite } from '../sprites';
+import { PathfindingManager, AgentMovementController } from '../pathfinding';
+import { DayNightCycle, TimeOfDay } from '../systems';
+import type { AgentStatus as ApiAgentStatus } from '@/lib/types';
+
+// Event callbacks for React integration
+type AgentClickCallback = (agentId: string) => void;
+type AreaChangeCallback = (area: TownArea) => void;
+type ViewportChangeCallback = (x: number, y: number, w: number, h: number) => void;
+
+let agentClickCallback: AgentClickCallback | null = null;
+let areaChangeCallback: AreaChangeCallback | null = null;
+let viewportChangeCallback: ViewportChangeCallback | null = null;
+
+export function setTownCallbacks(callbacks: {
+  onAgentClick?: AgentClickCallback | null;
+  onAreaChange?: AreaChangeCallback | null;
+  onViewportChange?: ViewportChangeCallback | null;
+}): void {
+  agentClickCallback = callbacks.onAgentClick ?? null;
+  areaChangeCallback = callbacks.onAreaChange ?? null;
+  viewportChangeCallback = callbacks.onViewportChange ?? null;
+}
+
+export class TownScene extends Phaser.Scene {
+  private collisionLayer: number[][] = [];
+  private agents: Map<string, AgentSprite> = new Map();
+  private agentData: Map<string, ApiAgentStatus> = new Map();
+  private pathfinder!: PathfindingManager;
+  private movementControllers: Map<string, AgentMovementController> = new Map();
+  private dayNightCycle!: DayNightCycle;
+  private currentArea: TownArea = 'office';
+  private timeText!: Phaser.GameObjects.Text;
+  private isDragging = false;
+  private dragStartX = 0;
+  private dragStartY = 0;
+  private pollTimer: number | null = null;
+
+  constructor() {
+    super({ key: 'TownScene' });
+  }
+
+  preload(): void {
+    // Tileset generation handled in create
+  }
+
+  create(): void {
+    const { width, height, layers } = TOWN_MAP;
+    const mapWidth = width * TILE_SIZE;
+    const mapHeight = height * TILE_SIZE;
+
+    this.collisionLayer = layers.collision;
+    this.pathfinder = new PathfindingManager();
+    this.pathfinder.setGrid(layers.collision);
+
+    // Render map layers
+    this.renderGroundLayer(layers.ground);
+    this.renderFurnitureLayer(layers.furniture);
+
+    // Set up day/night cycle (2 minute full cycle for demo)
+    this.dayNightCycle = new DayNightCycle(this, {
+      cycleDurationMs: 120000,
+      startTime: 'day',
+    });
+    this.dayNightCycle.create(mapWidth, mapHeight);
+    this.dayNightCycle.start();
+
+    // Time display
+    this.timeText = this.add.text(mapWidth - 80, 16, '12:00', {
+      fontSize: '12px',
+      color: '#ffffff',
+      fontFamily: 'monospace',
+      backgroundColor: '#1d2b53',
+      padding: { x: 4, y: 2 },
+    }).setDepth(101).setScrollFactor(0);
+
+    // Title
+    this.add.text(16, 16, 'Agent Town', {
+      fontSize: '16px',
+      color: '#ffffff',
+      fontFamily: 'monospace',
+      backgroundColor: '#1d2b53',
+      padding: { x: 8, y: 4 },
+    }).setDepth(100).setScrollFactor(0);
+
+    // Camera setup
+    this.cameras.main.setBounds(0, 0, mapWidth, mapHeight);
+    this.cameras.main.setZoom(1);
+
+    // Enable camera drag
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      if (pointer.rightButtonDown()) {
+        this.isDragging = true;
+        this.dragStartX = pointer.x;
+        this.dragStartY = pointer.y;
+      }
+    });
+
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      if (this.isDragging) {
+        const dx = this.dragStartX - pointer.x;
+        const dy = this.dragStartY - pointer.y;
+        this.cameras.main.scrollX += dx;
+        this.cameras.main.scrollY += dy;
+        this.dragStartX = pointer.x;
+        this.dragStartY = pointer.y;
+        this.notifyViewportChange();
+      }
+    });
+
+    this.input.on('pointerup', () => {
+      this.isDragging = false;
+    });
+
+    // Keyboard controls
+    this.input.keyboard?.on('keydown-ONE', () => this.navigateToArea('office'));
+    this.input.keyboard?.on('keydown-TWO', () => this.navigateToArea('park'));
+    this.input.keyboard?.on('keydown-THREE', () => this.navigateToArea('residential'));
+    this.input.keyboard?.on('keydown-FOUR', () => this.navigateToArea('coffeeShop'));
+    this.input.keyboard?.on('keydown-FIVE', () => this.navigateToArea('store'));
+
+    // Start polling for agents
+    this.startPolling();
+
+    // Start at office
+    this.navigateToArea('office');
+  }
+
+  private async startPolling(): Promise<void> {
+    await this.fetchAndUpdateAgents();
+    this.pollTimer = window.setInterval(() => {
+      this.fetchAndUpdateAgents();
+    }, 5000);
+  }
+
+  private async fetchAndUpdateAgents(): Promise<void> {
+    try {
+      const res = await fetch('/api/agents');
+      if (!res.ok) return;
+      const agents: ApiAgentStatus[] = await res.json();
+      
+      const newAgentIds = new Set(agents.map(a => a.agent_id));
+      
+      // Add/update agents
+      for (const agent of agents) {
+        if (!this.agents.has(agent.agent_id)) {
+          this.createAgent(agent);
+        } else {
+          this.updateAgentState(agent);
+        }
+        this.agentData.set(agent.agent_id, agent);
+      }
+      
+      // Remove agents no longer in list
+      for (const agentId of this.agents.keys()) {
+        if (!newAgentIds.has(agentId)) {
+          this.removeAgent(agentId);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch agents:', err);
+    }
+  }
+
+  private renderGroundLayer(layerData: number[][]): void {
+    for (let y = 0; y < layerData.length; y++) {
+      for (let x = 0; x < layerData[y].length; x++) {
+        const tileIndex = layerData[y][x];
+        this.drawGroundTile(x, y, tileIndex);
+      }
+    }
+  }
+
+  private drawGroundTile(tileX: number, tileY: number, tileIndex: number): void {
+    const graphics = this.add.graphics();
+    graphics.setDepth(0);
+    const x = tileX * TILE_SIZE;
+    const y = tileY * TILE_SIZE;
+
+    switch (tileIndex) {
+      case 0: // Light floor
+        graphics.fillStyle(PICO8_COLORS.lightGray);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.white);
+        graphics.fillRect(x + 2, y + 2, 4, 4);
+        break;
+      case 1: // Dark floor
+        graphics.fillStyle(PICO8_COLORS.darkGray);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        break;
+      case 2: // Carpet
+        graphics.fillStyle(PICO8_COLORS.darkBlue);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        break;
+      case 3: // Grass
+        graphics.fillStyle(PICO8_COLORS.darkGreen);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.green);
+        graphics.fillRect(x + 4, y + 8, 2, 4);
+        graphics.fillRect(x + 20, y + 16, 2, 4);
+        graphics.fillRect(x + 12, y + 24, 2, 4);
+        break;
+      case 4: // Road
+        graphics.fillStyle(PICO8_COLORS.darkGray);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.yellow);
+        graphics.fillRect(x + 14, y + 14, 4, 4);
+        break;
+      case 5: // Wooden floor
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.orange);
+        graphics.fillRect(x, y + 8, TILE_SIZE, 2);
+        graphics.fillRect(x, y + 24, TILE_SIZE, 2);
+        break;
+      case 6: // Tile floor
+        graphics.fillStyle(PICO8_COLORS.lightGray);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.white);
+        graphics.fillRect(x, y, 16, 16);
+        graphics.fillRect(x + 16, y + 16, 16, 16);
+        break;
+      default:
+        graphics.fillStyle(PICO8_COLORS.black);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+    }
+  }
+
+  private renderFurnitureLayer(layerData: number[][]): void {
+    for (let y = 0; y < layerData.length; y++) {
+      for (let x = 0; x < layerData[y].length; x++) {
+        const tileIndex = layerData[y][x];
+        if (tileIndex < 0) continue;
+        this.drawFurnitureTile(x, y, tileIndex);
+      }
+    }
+  }
+
+  private drawFurnitureTile(tileX: number, tileY: number, tileIndex: number): void {
+    const graphics = this.add.graphics();
+    graphics.setDepth(1);
+    const x = tileX * TILE_SIZE;
+    const y = tileY * TILE_SIZE;
+
+    switch (tileIndex) {
+      // Walls
+      case 10: // Top wall
+        graphics.fillStyle(PICO8_COLORS.darkPurple);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.lavender);
+        graphics.fillRect(x, y + TILE_SIZE - 4, TILE_SIZE, 4);
+        break;
+      case 11: // Bottom wall
+        graphics.fillStyle(PICO8_COLORS.darkPurple);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.lavender);
+        graphics.fillRect(x, y, TILE_SIZE, 4);
+        break;
+      case 12: // Left wall
+        graphics.fillStyle(PICO8_COLORS.darkPurple);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.lavender);
+        graphics.fillRect(x + TILE_SIZE - 4, y, 4, TILE_SIZE);
+        break;
+      case 13: // Right wall
+        graphics.fillStyle(PICO8_COLORS.darkPurple);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.lavender);
+        graphics.fillRect(x, y, 4, TILE_SIZE);
+        break;
+
+      // Office furniture
+      case 20: // Desk
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 2, y + 8, TILE_SIZE - 4, TILE_SIZE - 12);
+        break;
+      case 24: // Chair
+        graphics.fillStyle(PICO8_COLORS.blue);
+        graphics.fillRect(x + 8, y + 8, 16, 16);
+        break;
+      case 28: // Computer
+        graphics.fillStyle(PICO8_COLORS.black);
+        graphics.fillRect(x + 6, y + 4, 20, 14);
+        graphics.fillStyle(PICO8_COLORS.darkBlue);
+        graphics.fillRect(x + 8, y + 6, 16, 10);
+        break;
+      case 40: // Coffee machine
+        graphics.fillStyle(PICO8_COLORS.darkGray);
+        graphics.fillRect(x + 4, y + 4, 24, 24);
+        graphics.fillStyle(PICO8_COLORS.red);
+        graphics.fillRect(x + 20, y + 22, 4, 4);
+        break;
+      case 41: // Counter
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x, y + 8, TILE_SIZE, TILE_SIZE - 8);
+        break;
+      case 44: // Plant
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 10, y + 20, 12, 10);
+        graphics.fillStyle(PICO8_COLORS.green);
+        graphics.fillRect(x + 8, y + 8, 16, 14);
+        break;
+      case 50: // Meeting table
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x, y + 4, TILE_SIZE, TILE_SIZE - 4);
+        break;
+      case 54: // Whiteboard
+        graphics.fillStyle(PICO8_COLORS.white);
+        graphics.fillRect(x + 6, y + 4, 20, 22);
+        break;
+      case 60: // Door
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 4, y, 24, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.yellow);
+        graphics.fillRect(x + 20, y + 16, 4, 4);
+        break;
+
+      // Park
+      case 70: // Fence horizontal
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x, y + 12, TILE_SIZE, 8);
+        break;
+      case 71: // Fence vertical
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 12, y, 8, TILE_SIZE);
+        break;
+      case 72: // Tree
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 12, y + 16, 8, 16);
+        graphics.fillStyle(PICO8_COLORS.darkGreen);
+        graphics.fillCircle(x + 16, y + 12, 12);
+        break;
+      case 73: // Bench
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 4, y + 16, 24, 8);
+        graphics.fillRect(x + 6, y + 24, 4, 6);
+        graphics.fillRect(x + 22, y + 24, 4, 6);
+        break;
+      case 74: // Fountain
+        graphics.fillStyle(PICO8_COLORS.lightGray);
+        graphics.fillCircle(x + 16, y + 16, 14);
+        graphics.fillStyle(PICO8_COLORS.blue);
+        graphics.fillCircle(x + 16, y + 16, 10);
+        break;
+      case 75: // Flowers
+        graphics.fillStyle(PICO8_COLORS.pink);
+        graphics.fillCircle(x + 8, y + 20, 4);
+        graphics.fillCircle(x + 16, y + 18, 4);
+        graphics.fillCircle(x + 24, y + 22, 4);
+        break;
+
+      // Residential
+      case 80: // House
+        graphics.fillStyle(PICO8_COLORS.peach);
+        graphics.fillRect(x, y, TILE_SIZE, TILE_SIZE);
+        graphics.fillStyle(PICO8_COLORS.red);
+        graphics.fillRect(x, y, TILE_SIZE, 8);
+        break;
+      case 81: // Street lamp
+        graphics.fillStyle(PICO8_COLORS.darkGray);
+        graphics.fillRect(x + 14, y + 8, 4, 24);
+        graphics.fillStyle(PICO8_COLORS.yellow);
+        graphics.fillCircle(x + 16, y + 6, 6);
+        break;
+      case 82: // Mailbox
+        graphics.fillStyle(PICO8_COLORS.blue);
+        graphics.fillRect(x + 10, y + 16, 12, 10);
+        graphics.fillRect(x + 14, y + 26, 4, 6);
+        break;
+
+      // Coffee shop
+      case 90: // Coffee counter
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x, y + 4, TILE_SIZE, TILE_SIZE - 4);
+        graphics.fillStyle(PICO8_COLORS.orange);
+        graphics.fillRect(x, y + 4, TILE_SIZE, 4);
+        break;
+      case 91: // Cafe table
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillCircle(x + 16, y + 16, 10);
+        break;
+
+      // Store
+      case 92: // Store counter
+        graphics.fillStyle(PICO8_COLORS.lightGray);
+        graphics.fillRect(x, y + 4, TILE_SIZE, TILE_SIZE - 4);
+        break;
+      case 93: // Shelf
+        graphics.fillStyle(PICO8_COLORS.brown);
+        graphics.fillRect(x + 4, y + 4, 24, 24);
+        graphics.fillStyle(PICO8_COLORS.green);
+        graphics.fillRect(x + 8, y + 8, 6, 6);
+        graphics.fillStyle(PICO8_COLORS.red);
+        graphics.fillRect(x + 18, y + 8, 6, 6);
+        graphics.fillStyle(PICO8_COLORS.blue);
+        graphics.fillRect(x + 8, y + 18, 6, 6);
+        graphics.fillStyle(PICO8_COLORS.yellow);
+        graphics.fillRect(x + 18, y + 18, 6, 6);
+        break;
+    }
+  }
+
+  navigateToArea(area: TownArea): void {
+    const areaData = TOWN_MAP.areas[area];
+    if (!areaData) return;
+
+    this.currentArea = area;
+    
+    // Center camera on area
+    const centerX = (areaData.x + areaData.width / 2) * TILE_SIZE;
+    const centerY = (areaData.y + areaData.height / 2) * TILE_SIZE;
+    
+    this.cameras.main.pan(centerX, centerY, 500, 'Power2');
+    
+    if (areaChangeCallback) {
+      areaChangeCallback(area);
+    }
+    
+    this.notifyViewportChange();
+  }
+
+  private notifyViewportChange(): void {
+    if (viewportChangeCallback) {
+      const cam = this.cameras.main;
+      viewportChangeCallback(
+        cam.scrollX,
+        cam.scrollY,
+        cam.width,
+        cam.height
+      );
+    }
+  }
+
+  private createAgent(agentData: ApiAgentStatus): void {
+    if (this.agents.has(agentData.agent_id)) return;
+
+    const workstations = TOWN_MAP.locations.workstations;
+    const agentIndex = this.agents.size;
+    const workstation = workstations[agentIndex % workstations.length];
+    const tileX = workstation.x + 1;
+    const tileY = workstation.y + 1;
+
+    const agent = new AgentSprite(
+      this,
+      tileX * TILE_SIZE + TILE_SIZE / 2,
+      (tileY + 1) * TILE_SIZE,
+      agentData.agent_id
+    );
+
+    agent.setInteractive(new Phaser.Geom.Rectangle(-8, -24, 16, 24), Phaser.Geom.Rectangle.Contains);
+    agent.on('pointerdown', () => {
+      if (agentClickCallback) {
+        agentClickCallback(agentData.agent_id);
+      }
+    });
+    agent.on('pointerover', () => agent.setScale(1.1));
+    agent.on('pointerout', () => agent.setScale(1));
+
+    const controller = new AgentMovementController(this, agent, this.pathfinder);
+    controller.setPosition(tileX, tileY);
+    
+    this.movementControllers.set(agentData.agent_id, controller);
+    this.agents.set(agentData.agent_id, agent);
+    this.applyAgentStatus(agent, agentData.status);
+  }
+
+  private updateAgentState(agentData: ApiAgentStatus): void {
+    const agent = this.agents.get(agentData.agent_id);
+    if (agent) {
+      this.applyAgentStatus(agent, agentData.status);
+    }
+  }
+
+  private applyAgentStatus(agent: AgentSprite, status: string): void {
+    switch (status) {
+      case 'online':
+        agent.work();
+        agent.setVisible(true);
+        agent.setAlpha(1);
+        break;
+      case 'idle':
+        agent.rest();
+        agent.setVisible(true);
+        agent.setAlpha(1);
+        break;
+      case 'offline':
+        agent.idle();
+        agent.setAlpha(0.5);
+        break;
+      default:
+        agent.idle();
+    }
+  }
+
+  private removeAgent(agentId: string): void {
+    const agent = this.agents.get(agentId);
+    if (agent) {
+      agent.destroy();
+      this.agents.delete(agentId);
+    }
+    this.movementControllers.delete(agentId);
+    this.agentData.delete(agentId);
+  }
+
+  getCurrentArea(): TownArea {
+    return this.currentArea;
+  }
+
+  getTimeOfDay(): TimeOfDay {
+    return this.dayNightCycle.getCurrentTime();
+  }
+
+  update(): void {
+    this.dayNightCycle.update();
+    this.timeText.setText(this.dayNightCycle.getTimeString());
+    this.agents.forEach(agent => agent.updateDepth());
+  }
+
+  shutdown(): void {
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.dayNightCycle.destroy();
+  }
+}

--- a/src/game/systems/DayNightCycle.ts
+++ b/src/game/systems/DayNightCycle.ts
@@ -1,0 +1,169 @@
+import Phaser from 'phaser';
+import { PICO8_COLORS } from '../tiles/palette';
+
+export type TimeOfDay = 'day' | 'dusk' | 'night' | 'dawn';
+
+export interface DayNightConfig {
+  cycleDurationMs: number; // Full cycle duration
+  startTime?: TimeOfDay;
+}
+
+// Color tints for each time of day
+const TIME_TINTS: Record<TimeOfDay, number> = {
+  day: 0xffffff,    // No tint
+  dusk: 0xffaa77,   // Orange tint
+  night: 0x4466aa,  // Blue tint
+  dawn: 0xffddaa,   // Warm yellow
+};
+
+// Ambient light levels
+const AMBIENT_LEVELS: Record<TimeOfDay, number> = {
+  day: 1.0,
+  dusk: 0.8,
+  night: 0.5,
+  dawn: 0.7,
+};
+
+// Time distribution (percentage of cycle)
+const TIME_DISTRIBUTION: Record<TimeOfDay, { start: number; end: number }> = {
+  dawn: { start: 0, end: 0.1 },
+  day: { start: 0.1, end: 0.5 },
+  dusk: { start: 0.5, end: 0.6 },
+  night: { start: 0.6, end: 1.0 },
+};
+
+export class DayNightCycle {
+  private scene: Phaser.Scene;
+  private overlay: Phaser.GameObjects.Rectangle | null = null;
+  private currentTime: TimeOfDay = 'day';
+  private cycleProgress: number = 0;
+  private cycleDurationMs: number;
+  private isRunning: boolean = false;
+  private lastUpdateTime: number = 0;
+  private listeners: Set<(time: TimeOfDay) => void> = new Set();
+
+  constructor(scene: Phaser.Scene, config: DayNightConfig) {
+    this.scene = scene;
+    this.cycleDurationMs = config.cycleDurationMs;
+    if (config.startTime) {
+      this.currentTime = config.startTime;
+      this.cycleProgress = TIME_DISTRIBUTION[config.startTime].start;
+    }
+  }
+
+  create(width: number, height: number): void {
+    // Create overlay for tinting
+    this.overlay = this.scene.add.rectangle(
+      width / 2,
+      height / 2,
+      width,
+      height,
+      0x000000,
+      0
+    );
+    this.overlay.setDepth(1000);
+    this.overlay.setBlendMode(Phaser.BlendModes.MULTIPLY);
+    
+    this.updateVisuals();
+  }
+
+  start(): void {
+    this.isRunning = true;
+    this.lastUpdateTime = Date.now();
+  }
+
+  stop(): void {
+    this.isRunning = false;
+  }
+
+  update(): void {
+    if (!this.isRunning) return;
+
+    const now = Date.now();
+    const delta = now - this.lastUpdateTime;
+    this.lastUpdateTime = now;
+
+    // Update cycle progress
+    this.cycleProgress += delta / this.cycleDurationMs;
+    if (this.cycleProgress >= 1) {
+      this.cycleProgress -= 1;
+    }
+
+    // Determine current time of day
+    const newTime = this.getTimeOfDay();
+    if (newTime !== this.currentTime) {
+      this.currentTime = newTime;
+      this.notifyListeners();
+    }
+
+    this.updateVisuals();
+  }
+
+  private getTimeOfDay(): TimeOfDay {
+    for (const [time, range] of Object.entries(TIME_DISTRIBUTION)) {
+      if (this.cycleProgress >= range.start && this.cycleProgress < range.end) {
+        return time as TimeOfDay;
+      }
+    }
+    return 'day';
+  }
+
+  private updateVisuals(): void {
+    if (!this.overlay) return;
+
+    const tint = TIME_TINTS[this.currentTime];
+    const alpha = 1 - AMBIENT_LEVELS[this.currentTime];
+
+    // Smooth transition
+    const targetAlpha = Math.min(0.5, alpha);
+    this.overlay.setFillStyle(this.invertTint(tint), targetAlpha);
+  }
+
+  private invertTint(tint: number): number {
+    // Convert tint to overlay color
+    const r = 255 - ((tint >> 16) & 0xff);
+    const g = 255 - ((tint >> 8) & 0xff);
+    const b = 255 - (tint & 0xff);
+    return (r << 16) | (g << 8) | b;
+  }
+
+  setTime(time: TimeOfDay): void {
+    this.currentTime = time;
+    this.cycleProgress = TIME_DISTRIBUTION[time].start;
+    this.updateVisuals();
+    this.notifyListeners();
+  }
+
+  getCurrentTime(): TimeOfDay {
+    return this.currentTime;
+  }
+
+  getCycleProgress(): number {
+    return this.cycleProgress;
+  }
+
+  onTimeChange(callback: (time: TimeOfDay) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  private notifyListeners(): void {
+    this.listeners.forEach(cb => cb(this.currentTime));
+  }
+
+  // Get display string for current time
+  getTimeString(): string {
+    const hour = Math.floor(this.cycleProgress * 24);
+    const minute = Math.floor((this.cycleProgress * 24 * 60) % 60);
+    return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+  }
+
+  destroy(): void {
+    this.stop();
+    if (this.overlay) {
+      this.overlay.destroy();
+      this.overlay = null;
+    }
+    this.listeners.clear();
+  }
+}

--- a/src/game/systems/index.ts
+++ b/src/game/systems/index.ts
@@ -1,0 +1,1 @@
+export { DayNightCycle, type TimeOfDay, type DayNightConfig } from './DayNightCycle';


### PR DESCRIPTION
Closes #23

## Phase 3 完成！

### 实现内容：
- **城镇地图扩展** (40x30 tiles)：
  - 办公室（已有）
  - 公园（休闲区，有树、长椅、喷泉）
  - 住宅区（房屋、街灯、邮箱）
  - 咖啡店（柜台、桌椅）
  - 商店（货架、柜台）
- **昼夜循环系统**：
  - 白天 → 黄昏 → 夜晚 → 黎明
  - 2 分钟完整循环（可配置）
  - 时间显示
- **地图导航**：
  - 数字键 1-5 快速切换区域
  - 右键拖拽平移
  - 区域按钮导航
- **小地图**（简化版）

### 新增页面：
- /town — 完整城镇视图