### PR TITLE
feat: Visual enhancement P0 - buildings and villas (issue #40)

### DIFF
--- a/src/game/maps/town-map.ts
+++ b/src/game/maps/town-map.ts
@@ -14,16 +14,18 @@ function hash(x: number, y: number): number {
 }
 
 // Villa definitions: origin (top-left), 4 wide x 3 tall
-const VILLAS: { ox: number; oy: number; type: 'A' | 'B' }[] = [
+// Staggered Y layout for visual interest (odd villas offset by 1)
+const VILLAS: { ox: number; oy: number; type: 'A' | 'B' | 'C' }[] = [
   { ox: 5,  oy: 29, type: 'A' },
-  { ox: 13, oy: 29, type: 'B' },
-  { ox: 21, oy: 29, type: 'A' },
-  { ox: 29, oy: 29, type: 'B' },
-  { ox: 37, oy: 29, type: 'A' },
-  { ox: 45, oy: 29, type: 'B' },
+  { ox: 13, oy: 30, type: 'B' },  // y+1 offset
+  { ox: 21, oy: 29, type: 'C' },  // new green villa
+  { ox: 29, oy: 30, type: 'A' },  // y+1 offset
+  { ox: 37, oy: 29, type: 'B' },
+  { ox: 45, oy: 30, type: 'C' },  // y+1 offset, green villa
 ];
 const VILLA_A_BASE = 100;
 const VILLA_B_BASE = 112;
+const VILLA_C_BASE = 124;
 
 // ─── Pond shape (organic blob in park) ────────────────────────
 function isPond(x: number, y: number): boolean {
@@ -207,23 +209,51 @@ function getFurniture(x: number, y: number): number {
   for (const v of VILLAS) {
     const rx = x - v.ox, ry = y - v.oy;
     if (rx >= 0 && rx < 4 && ry >= 0 && ry < 3) {
-      const base = v.type === 'A' ? VILLA_A_BASE : VILLA_B_BASE;
+      const base = v.type === 'A' ? VILLA_A_BASE : v.type === 'B' ? VILLA_B_BASE : VILLA_C_BASE;
       return base + ry * 4 + rx;
     }
   }
 
+  // ── Villa front gardens (fence + flowerbed + mailbox combo) ──
+  for (let i = 0; i < VILLAS.length; i++) {
+    const v = VILLAS[i];
+    const gardenY = v.oy + 3; // row below villa
+    // Fence posts at garden corners
+    if (y === gardenY && (x === v.ox || x === v.ox + 3)) return 71; // fence vertical
+    // Flowerbed in front of door
+    if (y === gardenY && (x === v.ox + 1 || x === v.ox + 2)) return 75; // flowers
+    // Mailbox to the side
+    if (y === gardenY - 1 && x === v.ox - 1) return 82; // mailbox
+  }
+
+  // ── Landscaping between villas (trees, bushes, stone paths) ──
+  // Stone path segments between villas
+  if (y === 28 && (x === 10 || x === 11 || x === 18 || x === 19 || x === 26 || x === 27 || x === 34 || x === 35 || x === 42 || x === 43)) {
+    // These are on dirt path, skip
+  }
+
   // ── Residential decorations (gardens between villas) ──
-  if (y >= 27 && y <= 33 && x >= 4 && x <= 51 && g === 3) {
-    // Trees between villas
-    if (y === 30 && (x === 11 || x === 19 || x === 27 || x === 35 || x === 43)) return 72;
+  if (y >= 27 && y <= 34 && x >= 4 && x <= 51 && g === 3) {
+    // Trees between villas (adjusted for staggered layout)
+    if (y === 30 && (x === 11 || x === 27 || x === 43)) return 72;
+    if (y === 31 && (x === 19 || x === 35)) return 72;
+    // Bushes creating garden boundaries
+    if (y === 28 && (x === 10 || x === 18 || x === 26 || x === 34 || x === 42 || x === 50)) return 76;
+    if (y === 29 && (x === 12 || x === 20 || x === 28 || x === 36 || x === 44)) return 76;
     // Flower beds near villas
-    if (y === 32 && (x === 7 || x === 15 || x === 23 || x === 31 || x === 39 || x === 47)) return 75;
-    // Garden bushes
-    if (y === 28 && (x === 9 || x === 17 || x === 25 || x === 33 || x === 41 || x === 49)) return 76;
+    if (y === 33 && (x === 7 || x === 23 || x === 39)) return 75;
+    if (y === 34 && (x === 15 || x === 31 || x === 47)) return 75;
+    // Rock clusters for variety
+    if (y === 31 && (x === 11 || x === 27 || x === 43)) return 77;
     // Lamp posts along path
     if (y === 27 && (x === 5 || x === 13 || x === 21 || x === 29 || x === 37 || x === 45)) return 81;
-    // Mailboxes in front of villas
-    if (y === 32 && (x === 6 || x === 14 || x === 22 || x === 30 || x === 38 || x === 46)) return 82;
+    // Mailboxes in front of villas (adjusted for stagger)
+    if (y === 32 && x === 4) return 82;
+    if (y === 33 && x === 12) return 82;
+    if (y === 32 && x === 20) return 82;
+    if (y === 33 && x === 28) return 82;
+    if (y === 32 && x === 36) return 82;
+    if (y === 33 && x === 44) return 82;
   }
 
   // ── Bridge over river ──
@@ -308,7 +338,7 @@ function generateCollisionLayer(): number[][] {
       if (g === 7) { row.push(1); continue; }  // water
       if (g === 8) { row.push(1); continue; }  // forest (impassable)
       if (f === 60 || f === 85) { row.push(0); continue; } // doors & bridges
-      if (f >= 100 && f <= 123) { row.push(1); continue; } // villa body
+      if (f >= 100 && f <= 135) { row.push(1); continue; } // villa body (A, B, C)
       const solidFurniture = [10, 11, 12, 13, 20, 28, 40, 50, 54, 70, 71, 72, 74, 90, 92, 93];
       if (solidFurniture.includes(f)) { row.push(1); continue; }
       row.push(0);
@@ -368,11 +398,11 @@ export const TOWN_MAP = {
     ],
     homes: [
       { x: 6,  y: 32, id: 'villa-1', area: 'residential' },
-      { x: 14, y: 32, id: 'villa-2', area: 'residential' },
+      { x: 14, y: 33, id: 'villa-2', area: 'residential' },  // staggered
       { x: 22, y: 32, id: 'villa-3', area: 'residential' },
-      { x: 30, y: 32, id: 'villa-4', area: 'residential' },
+      { x: 30, y: 33, id: 'villa-4', area: 'residential' },  // staggered
       { x: 38, y: 32, id: 'villa-5', area: 'residential' },
-      { x: 46, y: 32, id: 'villa-6', area: 'residential' },
+      { x: 46, y: 33, id: 'villa-6', area: 'residential' },  // staggered
     ],
     cafeTables: [
       { x: 30, y: 19, id: 'cafe-1', area: 'coffeeShop' },

--- a/src/game/rendering/TownRenderer.ts
+++ b/src/game/rendering/TownRenderer.ts
@@ -86,21 +86,48 @@ export class TownRenderer {
         break;
       }
 
-      case 5: { // Wood floor (cafe)
+      case 5: { // Wood floor (cafe) — enhanced with wood grain and knots
         g.fillStyle(0xb8885a); g.fillRect(px, py, T, T);
         g.fillStyle(0xc89868, 0.45);
         g.fillRect(px + (tx % 2) * 16, py, 16, T);
+        // Wood grain lines
         g.fillStyle(0xa07848, 0.3);
         g.fillRect(px, py + 7, T, 1); g.fillRect(px, py + 15, T, 1); g.fillRect(px, py + 23, T, 1);
+        // Additional grain detail
+        g.fillStyle(0x9a6838, 0.2);
+        g.fillRect(px + 2, py + 3, 12, 1); g.fillRect(px + 18, py + 11, 10, 1); g.fillRect(px + 6, py + 19, 14, 1);
+        // Wood knots (pseudo-random based on position)
+        if (h % 7 === 0) {
+          g.fillStyle(0x8a5828, 0.35);
+          g.fillCircle(px + (h % 20) + 6, py + ((h >> 4) % 16) + 8, 2);
+        }
+        if (h % 11 === 0) {
+          g.fillStyle(0x7a4818, 0.25);
+          g.fillCircle(px + ((h >> 3) % 18) + 8, py + ((h >> 6) % 14) + 10, 1.5);
+        }
+        // Subtle shadow/highlight variation
+        g.fillStyle(0x000000, 0.03);
+        g.fillRect(px + (h % 12), py + ((h >> 2) % 10), 14, 12);
         break;
       }
 
-      case 6: { // Tile floor (store)
+      case 6: { // Tile floor (store) — enhanced with gloss reflection
         g.fillStyle(0xe0dcd0); g.fillRect(px, py, T, T);
         g.fillStyle(0xd0ccc0, 0.45);
         g.fillRect(px + 1, py + 1, 14, 14); g.fillRect(px + 17, py + 17, 14, 14);
         g.fillStyle(0xc8c4b8, 0.25);
         g.fillRect(px + 15, py, 2, T); g.fillRect(px, py + 15, T, 2);
+        // Subtle gloss reflection effect
+        g.fillStyle(0xffffff, 0.08);
+        g.fillRect(px + 2, py + 2, 10, 6);
+        g.fillRect(px + 18, py + 18, 10, 6);
+        // Micro highlight variation
+        g.fillStyle(0xffffff, 0.04);
+        g.fillRect(px + ((h % 8) + 4), py + ((h >> 3) % 6) + 2, 6, 3);
+        // Subtle shadow for depth
+        g.fillStyle(0x000000, 0.02);
+        g.fillRect(px + 8, py + 10, 6, 4);
+        g.fillRect(px + 22, py + 24, 8, 4);
         break;
       }
 
@@ -194,31 +221,46 @@ export class TownRenderer {
     const h = hash(tx, ty);
 
     // ─── Villa multi-tile rendering ───
-    if (tile >= 100 && tile <= 111) { this.drawVillaA(g, px, py, tile - 100); return; }
-    if (tile >= 112 && tile <= 123) { this.drawVillaB(g, px, py, tile - 112); return; }
+    if (tile >= 100 && tile <= 111) { this.drawVillaA(g, px, py, tile - 100, tx, ty); return; }
+    if (tile >= 112 && tile <= 123) { this.drawVillaB(g, px, py, tile - 112, tx, ty); return; }
+    if (tile >= 124 && tile <= 135) { this.drawVillaC(g, px, py, tile - 124, tx, ty); return; }
 
     switch (tile) {
-      // ─── Walls (warm stone, thin band) ───
-      case 10: // top wall — thin band at bottom, roof hint at top
-        g.fillStyle(0xb8a888, 0.15); g.fillRect(px, py, T, T - 6);
-        g.fillStyle(0x9a8a70); g.fillRect(px, py + T - 8, T, 8);
-        g.fillStyle(0xb0a080); g.fillRect(px, py + T - 6, T, 2);
+      // ─── Walls (warm stone, enhanced with windows) ───
+      case 10: { // top wall — thicker band with roof tiles and windows
+        g.fillStyle(0xb8a888, 0.15); g.fillRect(px, py, T, T - 10);
+        // Roof tile effect at top
+        g.fillStyle(0xcc7755); g.fillRect(px, py, T, 3);
+        g.fillStyle(0xbb6644); g.fillRect(px, py + 3, T, 2);
+        // Wall body (10-12px)
+        g.fillStyle(0x9a8a70); g.fillRect(px, py + T - 12, T, 12);
+        g.fillStyle(0xb0a080); g.fillRect(px, py + T - 10, T, 2);
         g.fillStyle(0xc0b090, 0.5); g.fillRect(px, py + T - 2, T, 2);
+        // Window detail on long walls (every other tile)
+        if (tx % 3 === 1) {
+          g.fillStyle(0x88aacc); g.fillRect(px + 10, py + T - 9, 12, 6);
+          g.fillStyle(0x7a6a5a); g.fillRect(px + 10, py + T - 9, 12, 1);
+          g.fillRect(px + 10, py + T - 4, 12, 1);
+          g.fillRect(px + 10, py + T - 9, 1, 6);
+          g.fillRect(px + 21, py + T - 9, 1, 6);
+          g.fillStyle(0x000000, 0.1); g.fillRect(px + 16, py + T - 9, 1, 6);
+        }
         break;
-      case 11: // bottom wall
-        g.fillStyle(0x9a8a70); g.fillRect(px, py, T, 8);
-        g.fillStyle(0xb0a080); g.fillRect(px, py + 4, T, 2);
-        g.fillStyle(0xb8a888, 0.15); g.fillRect(px, py + 8, T, T - 8);
+      }
+      case 11: // bottom wall — thicker
+        g.fillStyle(0x9a8a70); g.fillRect(px, py, T, 10);
+        g.fillStyle(0xb0a080); g.fillRect(px, py + 6, T, 2);
+        g.fillStyle(0xb8a888, 0.15); g.fillRect(px, py + 10, T, T - 10);
         break;
-      case 12: // left wall
-        g.fillStyle(0x9a8a70); g.fillRect(px + T - 8, py, 8, T);
-        g.fillStyle(0xb0a080); g.fillRect(px + T - 6, py, 2, T);
-        g.fillStyle(0xb8a888, 0.12); g.fillRect(px, py, T - 8, T);
+      case 12: // left wall — thicker (10px)
+        g.fillStyle(0x9a8a70); g.fillRect(px + T - 10, py, 10, T);
+        g.fillStyle(0xb0a080); g.fillRect(px + T - 8, py, 2, T);
+        g.fillStyle(0xb8a888, 0.12); g.fillRect(px, py, T - 10, T);
         break;
-      case 13: // right wall
-        g.fillStyle(0x9a8a70); g.fillRect(px, py, 8, T);
-        g.fillStyle(0xb0a080); g.fillRect(px + 4, py, 2, T);
-        g.fillStyle(0xb8a888, 0.12); g.fillRect(px + 8, py, T - 8, T);
+      case 13: // right wall — thicker (10px)
+        g.fillStyle(0x9a8a70); g.fillRect(px, py, 10, T);
+        g.fillStyle(0xb0a080); g.fillRect(px + 6, py, 2, T);
+        g.fillStyle(0xb8a888, 0.12); g.fillRect(px + 10, py, T - 10, T);
         break;
 
       // ─── Office furniture ───
@@ -267,10 +309,15 @@ export class TownRenderer {
         g.fillStyle(0x3366cc, 0.6); g.fillRect(px + 8, py + 8, 14, 2); g.fillRect(px + 8, py + 13, 10, 2);
         g.fillStyle(0xcc3333, 0.5); g.fillRect(px + 8, py + 18, 16, 2);
         break;
-      case 60: // door
-        g.fillStyle(0x8b6246); g.fillRect(px + 6, py + 2, 20, T - 2);
-        g.fillStyle(0x7a5236, 0.5); g.fillRect(px + 9, py + 5, 14, 10); g.fillRect(px + 9, py + 18, 14, 10);
-        g.fillStyle(0xccaa44); g.fillRect(px + 21, py + 16, 3, 4);
+      case 60: // door — with welcome mat/step
+        // Welcome mat / step
+        g.fillStyle(0x8a6a4a); g.fillRect(px + 4, py + T - 6, 24, 6);
+        g.fillStyle(0x9a7a5a); g.fillRect(px + 6, py + T - 5, 20, 4);
+        g.fillStyle(0x7a5a3a, 0.4); g.fillRect(px + 8, py + T - 4, 16, 2);
+        // Door
+        g.fillStyle(0x8b6246); g.fillRect(px + 6, py + 2, 20, T - 8);
+        g.fillStyle(0x7a5236, 0.5); g.fillRect(px + 9, py + 5, 14, 10); g.fillRect(px + 9, py + 18, 14, 6);
+        g.fillStyle(0xccaa44); g.fillRect(px + 21, py + 14, 3, 4);
         break;
 
       // ─── Park furniture ───
@@ -391,8 +438,9 @@ export class TownRenderer {
   }
 
   // ─── Villa Type A (warm: terracotta roof, cream walls) ─────
-  private drawVillaA(g: Phaser.GameObjects.Graphics, px: number, py: number, rel: number): void {
+  private drawVillaA(g: Phaser.GameObjects.Graphics, px: number, py: number, rel: number, tx: number, ty: number): void {
     const rx = rel % 4, ry = Math.floor(rel / 4);
+    const h = hash(tx, ty);
     const ROOF = 0xcc6655, ROOF_HI = 0xdd7766, ROOF_EDGE = 0xbb5544;
     const WALL = 0xf5e8d0, WALL_TRIM = 0xe8d8c0;
     const WIN = 0xccddee, WIN_FRAME = 0x8a7a6a;
@@ -404,7 +452,17 @@ export class TownRenderer {
       g.fillStyle(ROOF_EDGE); g.fillRect(px, py + T - 4, T, 4);
       if (rx === 0) { g.fillStyle(ROOF_EDGE); g.fillRect(px, py, 4, T); } // left edge
       if (rx === 3) { g.fillStyle(ROOF_EDGE); g.fillRect(px + T - 4, py, 4, T); } // right edge
-      if (rx === 0) { g.fillStyle(0x8a7a6a); g.fillRect(px + 6, py, 6, 10); g.fillStyle(0x7a6a5a); g.fillRect(px + 7, py, 4, 8); } // chimney
+      if (rx === 0) {
+        // Chimney with smoke effect
+        g.fillStyle(0x8a7a6a); g.fillRect(px + 6, py, 6, 10);
+        g.fillStyle(0x7a6a5a); g.fillRect(px + 7, py, 4, 8);
+        // Smoke puffs (simple static particles)
+        if (h % 3 === 0) {
+          g.fillStyle(0xcccccc, 0.3); g.fillCircle(px + 9, py - 4, 3);
+          g.fillStyle(0xdddddd, 0.2); g.fillCircle(px + 7, py - 8, 2);
+          g.fillStyle(0xeeeeee, 0.15); g.fillCircle(px + 10, py - 11, 2);
+        }
+      }
       // Ridge line
       g.fillStyle(0xbb5544, 0.5); g.fillRect(px, py + 10, T, 2);
     } else if (ry === 1) { // Wall row
@@ -437,8 +495,9 @@ export class TownRenderer {
   }
 
   // ─── Villa Type B (cool: slate blue roof, light gray walls) ─
-  private drawVillaB(g: Phaser.GameObjects.Graphics, px: number, py: number, rel: number): void {
+  private drawVillaB(g: Phaser.GameObjects.Graphics, px: number, py: number, rel: number, tx: number, ty: number): void {
     const rx = rel % 4, ry = Math.floor(rel / 4);
+    const h = hash(tx, ty);
     const ROOF = 0x6688aa, ROOF_HI = 0x7799bb, ROOF_EDGE = 0x557799;
     const WALL = 0xe0e8f0, WALL_TRIM = 0xd0d8e0;
     const WIN = 0xccddee, WIN_FRAME = 0x7a8a9a;
@@ -450,7 +509,16 @@ export class TownRenderer {
       g.fillStyle(ROOF_EDGE); g.fillRect(px, py + T - 4, T, 4);
       if (rx === 0) { g.fillStyle(ROOF_EDGE); g.fillRect(px, py, 4, T); }
       if (rx === 3) { g.fillStyle(ROOF_EDGE); g.fillRect(px + T - 4, py, 4, T); }
-      if (rx === 3) { g.fillStyle(0x7a8a9a); g.fillRect(px + T - 12, py, 6, 10); g.fillStyle(0x6a7a8a); g.fillRect(px + T - 11, py, 4, 8); }
+      if (rx === 3) {
+        // Chimney with smoke effect
+        g.fillStyle(0x7a8a9a); g.fillRect(px + T - 12, py, 6, 10);
+        g.fillStyle(0x6a7a8a); g.fillRect(px + T - 11, py, 4, 8);
+        // Smoke puffs
+        if (h % 4 === 0) {
+          g.fillStyle(0xcccccc, 0.25); g.fillCircle(px + T - 9, py - 3, 2.5);
+          g.fillStyle(0xdddddd, 0.18); g.fillCircle(px + T - 11, py - 7, 2);
+        }
+      }
       g.fillStyle(ROOF_EDGE, 0.5); g.fillRect(px, py + 10, T, 2);
     } else if (ry === 1) {
       g.fillStyle(WALL); g.fillRect(px, py, T, T);
@@ -478,6 +546,63 @@ export class TownRenderer {
       }
       if (rx === 0) { g.fillStyle(0x8a9aaa); g.fillRect(px, py, 2, T); }
       if (rx === 3) { g.fillStyle(0x8a9aaa); g.fillRect(px + T - 2, py, 2, T); }
+    }
+  }
+
+  // ─── Villa Type C (green: forest green roof, warm beige walls) ─
+  private drawVillaC(g: Phaser.GameObjects.Graphics, px: number, py: number, rel: number, tx: number, ty: number): void {
+    const rx = rel % 4, ry = Math.floor(rel / 4);
+    const h = hash(tx, ty);
+    const ROOF = 0x4a8a5a, ROOF_HI = 0x5a9a6a, ROOF_EDGE = 0x3a7a4a;
+    const WALL = 0xf0e8d8, WALL_TRIM = 0xe0d8c8;
+    const WIN = 0xccddee, WIN_FRAME = 0x7a8a7a;
+    const DOOR = 0x7b5236, KNOB = 0xccaa44;
+
+    if (ry === 0) { // Roof row
+      g.fillStyle(ROOF); g.fillRect(px, py, T, T);
+      g.fillStyle(ROOF_HI); g.fillRect(px, py + 2, T, T - 8);
+      g.fillStyle(ROOF_EDGE); g.fillRect(px, py + T - 4, T, 4);
+      if (rx === 0) { g.fillStyle(ROOF_EDGE); g.fillRect(px, py, 4, T); }
+      if (rx === 3) { g.fillStyle(ROOF_EDGE); g.fillRect(px + T - 4, py, 4, T); }
+      // Chimney on center-left
+      if (rx === 1) {
+        g.fillStyle(0x8a8a7a); g.fillRect(px + 4, py, 6, 10);
+        g.fillStyle(0x7a7a6a); g.fillRect(px + 5, py, 4, 8);
+        // Smoke puffs
+        if (h % 2 === 0) {
+          g.fillStyle(0xcccccc, 0.28); g.fillCircle(px + 7, py - 4, 2.5);
+          g.fillStyle(0xdddddd, 0.2); g.fillCircle(px + 5, py - 8, 2);
+          g.fillStyle(0xeeeeee, 0.12); g.fillCircle(px + 8, py - 12, 1.5);
+        }
+      }
+      // Ridge line
+      g.fillStyle(ROOF_EDGE, 0.5); g.fillRect(px, py + 10, T, 2);
+    } else if (ry === 1) { // Wall row
+      g.fillStyle(WALL); g.fillRect(px, py, T, T);
+      g.fillStyle(WALL_TRIM); g.fillRect(px, py, T, 2);
+      if (rx === 0 || rx === 3) {
+        g.fillStyle(WIN); g.fillRect(px + 8, py + 8, 16, 14);
+        g.fillStyle(WIN_FRAME); g.fillRect(px + 8, py + 8, 16, 1); g.fillRect(px + 8, py + 8, 1, 14); g.fillRect(px + 23, py + 8, 1, 14); g.fillRect(px + 8, py + 21, 16, 1);
+        g.fillStyle(0x000000, 0.1); g.fillRect(px + 16, py + 8, 1, 14); g.fillRect(px + 8, py + 14, 16, 1);
+      } else {
+        g.fillStyle(WALL_TRIM, 0.3); g.fillRect(px + 4, py + 10, T - 8, 12);
+      }
+      if (rx === 0) { g.fillStyle(0x8a9a8a); g.fillRect(px, py, 2, T); }
+      if (rx === 3) { g.fillStyle(0x8a9a8a); g.fillRect(px + T - 2, py, 2, T); }
+    } else { // Ground row
+      g.fillStyle(WALL); g.fillRect(px, py, T, T);
+      g.fillStyle(0xc8c0b0); g.fillRect(px, py + T - 4, T, 4); // foundation
+      if (rx === 1) { // door
+        g.fillStyle(DOOR); g.fillRect(px + 6, py + 2, 20, T - 6);
+        g.fillStyle(0x6a4228, 0.4); g.fillRect(px + 10, py + 5, 12, 10); g.fillRect(px + 10, py + 18, 12, 6);
+        g.fillStyle(KNOB); g.fillRect(px + 21, py + 16, 3, 3);
+      } else if (rx === 2) { // window
+        g.fillStyle(WIN); g.fillRect(px + 6, py + 4, 20, 16);
+        g.fillStyle(WIN_FRAME); g.fillRect(px + 6, py + 4, 20, 1); g.fillRect(px + 6, py + 19, 20, 1); g.fillRect(px + 6, py + 4, 1, 16); g.fillRect(px + 25, py + 4, 1, 16);
+        g.fillStyle(0x000000, 0.1); g.fillRect(px + 16, py + 4, 1, 16); g.fillRect(px + 6, py + 12, 20, 1);
+      }
+      if (rx === 0) { g.fillStyle(0x8a9a8a); g.fillRect(px, py, 2, T); }
+      if (rx === 3) { g.fillStyle(0x8a9a8a); g.fillRect(px + T - 2, py, 2, T); }
     }
   }
 


### PR DESCRIPTION
Partial fix for #40

## P0 任务 1：建筑墙壁和室内更精致
- 墙壁增加到 10-12px 宽
- 顶墙添加窗户细节（每隔几个 tile 画小窗）
- 建筑屋顶效果：顶墙上方添加 2-3px 屋顶瓦片色条
- 咖啡厅木地板增加木纹线条和节疤
- 商店地板增加微妙的光泽反射效果
- 建筑入口处添加欢迎垫/台阶视觉提示

## P0 任务 2：别墅区更有生活气息
- 别墅 Y 轴交错排列（奇数栋 y+1 偏移）
- 每栋别墅前添加小花园：围栏 + 花坛 + 信箱组合
- 别墅之间添加小型景观：树、灌木丛
- 增加第 3 种别墅配色（绿色系屋顶）VILLA_C
- 部分别墅增加烟囱冒烟效果（简单静态粒子）