### PR TITLE
fix: Agent teleport, animation loop, and text clarity

### DIFF
--- a/src/game/pathfinding/AgentMovementController.ts
+++ b/src/game/pathfinding/AgentMovementController.ts
@@ -199,25 +199,59 @@ export class AgentMovementController {
     return dy > 0 ? 'down' : 'up';
   }
 
-  // Stop current movement
+  // Stop current movement - smoothly complete to nearest tile instead of snapping
   stopMovement(): void {
     this.isMoving = false;
     this.isStepInProgress = false;
     
     if (this.currentTween) {
+      const progress = this.currentTween.progress;
+      
+      // Stop the current tween
       this.currentTween.stop();
       this.currentTween = undefined;
+      
+      if (progress > 0.5) {
+        // More than halfway - complete to the next tile smoothly
+        const nextNode = this.currentPath[this.pathIndex];
+        if (nextNode) {
+          const targetX = nextNode.x * TILE_SIZE + TILE_SIZE / 2;
+          const targetY = (nextNode.y + 1) * TILE_SIZE;
+          
+          this.scene.tweens.add({
+            targets: this.sprite,
+            x: targetX,
+            y: targetY,
+            duration: 100,
+            ease: 'Linear',
+            onComplete: () => {
+              this.currentTileX = nextNode.x;
+              this.currentTileY = nextNode.y;
+              this.sprite.idle();
+            },
+          });
+        } else {
+          this.sprite.idle();
+        }
+      } else {
+        // Less than halfway - go back to current tile smoothly
+        const currentTilePixelX = this.currentTileX * TILE_SIZE + TILE_SIZE / 2;
+        const currentTilePixelY = (this.currentTileY + 1) * TILE_SIZE;
+        
+        this.scene.tweens.add({
+          targets: this.sprite,
+          x: currentTilePixelX,
+          y: currentTilePixelY,
+          duration: 100,
+          ease: 'Linear',
+          onComplete: () => {
+            this.sprite.idle();
+          },
+        });
+      }
+    } else {
+      this.sprite.idle();
     }
-
-    // Snap to nearest tile center to prevent floating between tiles
-    const nearestTileX = Math.round((this.sprite.x - TILE_SIZE / 2) / TILE_SIZE);
-    const nearestTileY = Math.round(this.sprite.y / TILE_SIZE) - 1;
-    this.sprite.setPosition(
-      nearestTileX * TILE_SIZE + TILE_SIZE / 2,
-      (nearestTileY + 1) * TILE_SIZE
-    );
-    this.currentTileX = nearestTileX;
-    this.currentTileY = nearestTileY;
 
     // Release previously occupied tile if different from current
     if (this.targetTileX !== this.currentTileX || this.targetTileY !== this.currentTileY) {
@@ -238,15 +272,42 @@ export class AgentMovementController {
     return Math.max(0, this.currentPath.length - this.pathIndex);
   }
 
-  // Set position directly (for initialization)
-  setPosition(tileX: number, tileY: number): void {
-    this.currentTileX = tileX;
-    this.currentTileY = tileY;
-    this.sprite.setPosition(
-      tileX * TILE_SIZE + TILE_SIZE / 2,
-      (tileY + 1) * TILE_SIZE
-    );
-    this.sprite.updateDepth();
+  // Set position directly (for initialization only, not during gameplay)
+  setPosition(tileX: number, tileY: number, animate: boolean = false): void {
+    // Stop any existing movement first
+    if (this.currentTween) {
+      this.currentTween.stop();
+      this.currentTween = undefined;
+    }
+    this.isMoving = false;
+    this.isStepInProgress = false;
+    
+    const targetPixelX = tileX * TILE_SIZE + TILE_SIZE / 2;
+    const targetPixelY = (tileY + 1) * TILE_SIZE;
+    
+    if (animate && this.scene) {
+      // Smooth transition for position updates during gameplay
+      this.scene.tweens.add({
+        targets: this.sprite,
+        x: targetPixelX,
+        y: targetPixelY,
+        duration: 200,
+        ease: 'Linear',
+        onUpdate: () => {
+          this.sprite.updateDepth();
+        },
+        onComplete: () => {
+          this.currentTileX = tileX;
+          this.currentTileY = tileY;
+        },
+      });
+    } else {
+      // Direct set for initialization
+      this.currentTileX = tileX;
+      this.currentTileY = tileY;
+      this.sprite.setPosition(targetPixelX, targetPixelY);
+      this.sprite.updateDepth();
+    }
   }
 
   // Destroy controller

--- a/src/game/scenes/TownScene.ts
+++ b/src/game/scenes/TownScene.ts
@@ -346,8 +346,8 @@ export class TownScene extends Phaser.Scene {
     const screenY = (agent.y - this.cameras.main.scrollY) * this.cameras.main.zoom;
     
     // Panel dimensions
-    const panelWidth = 140;
-    const panelHeight = 80;
+    const panelWidth = 160;
+    const panelHeight = 100;
     
     // Position panel above agent, clamped to screen
     let panelX = screenX - panelWidth / 2;
@@ -366,50 +366,55 @@ export class TownScene extends Phaser.Scene {
     bg.strokeRoundedRect(0, 0, panelWidth, panelHeight, 6);
     this.detailPanel.add(bg);
     
-    // Agent name
+    // Agent name - larger font with higher resolution
     const shortName = agentId.replace(/-/g, ' ').slice(0, 15);
-    const nameText = this.add.text(panelWidth / 2, 8, shortName, {
-      fontSize: '8px',
+    const nameText = this.add.text(panelWidth / 2, 10, shortName, {
+      fontSize: '10px',
       fontFamily: '"Press Start 2P", monospace',
       color: '#ffffff',
+      resolution: 2,
     });
     nameText.setOrigin(0.5, 0);
     this.detailPanel.add(nameText);
     
-    // Status with color indicator
+    // Status with color indicator - larger font
     const statusColor = data.status === 'online' ? '#44ff44' : data.status === 'idle' ? '#ffaa44' : '#888888';
-    const statusText = this.add.text(10, 24, `● ${data.status.toUpperCase()}`, {
-      fontSize: '7px',
+    const statusText = this.add.text(12, 30, `● ${data.status.toUpperCase()}`, {
+      fontSize: '9px',
       fontFamily: '"Press Start 2P", monospace',
       color: statusColor,
+      resolution: 2,
     });
     this.detailPanel.add(statusText);
     
-    // Activity
+    // Activity - larger font with better contrast
     const activity = agent.getActivity();
-    const activityText = this.add.text(10, 38, `Activity: ${activity}`, {
-      fontSize: '6px',
-      fontFamily: 'monospace',
-      color: '#cccccc',
+    const activityText = this.add.text(12, 48, `Activity: ${activity}`, {
+      fontSize: '8px',
+      fontFamily: '"Press Start 2P", monospace',
+      color: '#e0e0e0',
+      resolution: 2,
     });
     this.detailPanel.add(activityText);
     
-    // Location
+    // Location - larger font
     const location = agent.getLocation();
-    const locationText = this.add.text(10, 52, `Location: ${location}`, {
-      fontSize: '6px',
-      fontFamily: 'monospace',
-      color: '#cccccc',
+    const locationText = this.add.text(12, 64, `Location: ${location}`, {
+      fontSize: '8px',
+      fontFamily: '"Press Start 2P", monospace',
+      color: '#e0e0e0',
+      resolution: 2,
     });
     this.detailPanel.add(locationText);
     
-    // Mood
+    // Mood - larger font
     const mood = agent.getMood();
     const moodEmoji = mood === 'happy' ? '😊' : mood === 'focused' ? '🎯' : mood === 'tired' ? '😴' : '😐';
-    const moodText = this.add.text(10, 66, `Mood: ${moodEmoji} ${mood}`, {
-      fontSize: '6px',
-      fontFamily: 'monospace',
-      color: '#cccccc',
+    const moodText = this.add.text(12, 80, `Mood: ${moodEmoji} ${mood}`, {
+      fontSize: '8px',
+      fontFamily: '"Press Start 2P", monospace',
+      color: '#e0e0e0',
+      resolution: 2,
     });
     this.detailPanel.add(moodText);
     

--- a/src/game/sprites/AgentSprite.ts
+++ b/src/game/sprites/AgentSprite.ts
@@ -85,22 +85,24 @@ export class AgentSprite extends Phaser.GameObjects.Container {
     this.statusIndicator.setPosition(0, -SPRITE_CONFIG.frameHeight - 4);
     this.add(this.statusIndicator);
 
-    // Name label above head
+    // Name label above head - higher resolution for clarity
     const shortName = agentId.replace(/-/g, '').toUpperCase().slice(0, 5);
     this.nameLabel = scene.add.text(0, -SPRITE_CONFIG.frameHeight - 10, shortName, {
-      fontSize: '7px',
+      fontSize: '8px',
       fontFamily: '"Press Start 2P", monospace',
       color: '#ffffff',
       stroke: '#000000',
-      strokeThickness: 2,
+      strokeThickness: 3,
+      resolution: 2,
     });
     this.nameLabel.setOrigin(0.5, 1);
     this.add(this.nameLabel);
 
-    // Status icon above name (emoji-based)
+    // Status icon above name (emoji-based) - higher resolution
     this.statusIcon = scene.add.text(0, -SPRITE_CONFIG.frameHeight - 22, '☕', {
-      fontSize: '12px',
+      fontSize: '14px',
       fontFamily: 'Arial, sans-serif',
+      resolution: 2,
     });
     this.statusIcon.setOrigin(0.5, 1);
     this.add(this.statusIcon);
@@ -373,14 +375,19 @@ export class AgentSprite extends Phaser.GameObjects.Container {
     }
   }
 
-  // Play animation by state
+  // Play animation by state - only switch when state actually changes
   playAnimation(state: AnimationState): void {
-    if (this.currentState === state && this.sprite.anims.isPlaying) return;
+    // Skip if already playing this exact animation
+    const animKey = this.animManager.getAnimationKey(this.textureKey, state);
+    const currentAnimKey = this.sprite.anims.currentAnim?.key;
+    
+    if (currentAnimKey === animKey && this.sprite.anims.isPlaying) {
+      return;
+    }
     
     this.currentState = state;
     this.animManager.state = state;
     
-    const animKey = this.animManager.getAnimationKey(this.textureKey, state);
     this.sprite.play(animKey);
 
     // Update status indicator
@@ -489,6 +496,8 @@ export class AgentSprite extends Phaser.GameObjects.Container {
       this.wanderTimer.destroy();
       this.wanderTimer = null;
     }
+    // Kill any active wander tweens on this container
+    this.scene.tweens.killTweensOf(this);
   }
 
   private scheduleNextWander(): void {
@@ -538,6 +547,9 @@ export class AgentSprite extends Phaser.GameObjects.Container {
       const distance = Math.sqrt(dx * dx + dy * dy);
       const duration = Math.max(600, distance * 20); // Slower, more natural pace
       
+      // Kill any existing wander tweens on this sprite before starting new one
+      this.scene.tweens.killTweensOf(this);
+      
       // Tween to target position
       this.scene.tweens.add({
         targets: this,
@@ -549,8 +561,10 @@ export class AgentSprite extends Phaser.GameObjects.Container {
           this.updateDepth();
         },
         onComplete: () => {
-          this.idle();
-          this.scheduleNextWander();
+          if (this.isWandering) {
+            this.idle();
+            this.scheduleNextWander();
+          }
         },
       });
     } else {


### PR DESCRIPTION
## 修复内容

### 问题 1：Agent 瞬移
- **原因**：`stopMovement()` 直接调用 `setPosition` 导致位置跳变
- **修复**：改为平滑过渡到最近的 tile，根据 tween 进度决定是完成到目标还是返回起点

### 问题 2：移动动画重复
- **原因**：`playAnimation()` 只检查 state 字符串，但 idle 动画 repeat=0 会停止，导致重复触发
- **修复**：改为检查实际的 animation key，只有当 key 不同或动画未播放时才切换

### 问题 3：点击详情文字模糊
- **原因**：Phaser Text 字体太小（6-8px），且未设置 resolution
- **修复**：
  - AgentSprite nameLabel: 7px → 8px，添加 `resolution: 2`
  - AgentSprite statusIcon: 12px → 14px，添加 `resolution: 2`
  - TownScene detailPanel: 所有文字增大到 8-10px，添加 `resolution: 2`
  - 面板尺寸从 140x80 增大到 160x100

### 其他改进
- `stopWandering()` 现在会 kill 所有活跃的 wander tweens，防止与 MovementController 冲突
- `performWander()` 在启动新 tween 前先 kill 已有的 tweens