### PR TITLE
feat: Agent detail panel (closes #52)

### DIFF
--- a/src/app/api/agents/[id]/detail/route.ts
+++ b/src/app/api/agents/[id]/detail/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+const AGENT_NAMES: Record<string, { name: string; role: string }> = {
+  secretary: { name: "刘亦菲", role: "首席秘书官" },
+  cto: { name: "扫地僧", role: "首席技术官" },
+  "dev-lead": { name: "韦小宝", role: "研发主管" },
+  cpo: { name: "乔布斯", role: "首席产品官" },
+  uiux: { name: "高圆圆", role: "UI/UX 设计师" },
+  cmo: { name: "达达里奥", role: "首席营销官" },
+  culture: { name: "李子柒", role: "文化顾问" },
+  hardware: { name: "马斯克", role: "硬件专家" },
+  advisor: { name: "巴菲特", role: "战略顾问" },
+};
+
+function extractEventSummary(eventType: string, payload: Record<string, unknown> | null): string {
+  if (!eventType) return "未知操作";
+
+  switch (eventType) {
+    case "sessions_spawn": {
+      const target = payload?.agentId || payload?.target || "子任务";
+      return `派发任务给 ${target}`;
+    }
+    case "tool_call": {
+      const tool = payload?.tool || payload?.name || "工具";
+      return `执行 ${tool}`;
+    }
+    case "message": {
+      const role = payload?.role as string;
+      if (role === "assistant") {
+        const content = payload?.content as string;
+        if (content) return content.slice(0, 100) + (content.length > 100 ? "..." : "");
+        return "回复消息";
+      }
+      if (role === "user") {
+        const content = payload?.content as string;
+        if (content) return `Darren: ${content.slice(0, 80)}${content.length > 80 ? "..." : ""}`;
+        return "收到消息";
+      }
+      return "消息交互";
+    }
+    case "tool_result": {
+      const tool = payload?.tool || payload?.name || "";
+      const result = payload?.result as string;
+      if (tool) return `${tool} 完成`;
+      if (result) return result.slice(0, 80) + (result.length > 80 ? "..." : "");
+      return "工具执行完成";
+    }
+    case "code_edit":
+    case "file_write": {
+      const file = payload?.file || payload?.path || "文件";
+      return `编辑 ${file}`;
+    }
+    case "thinking":
+      return "思考中...";
+    case "assistant_message": {
+      const content = payload?.content as string;
+      if (content) return content.slice(0, 100) + (content.length > 100 ? "..." : "");
+      return "生成回复";
+    }
+    default:
+      return `执行 ${eventType}`;
+  }
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleTimeString("zh-CN", { hour: "2-digit", minute: "2-digit" });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: agentId } = await params;
+    const supabase = await createClient();
+    const now = new Date();
+    const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+    const thirtyMinAgo = new Date(now.getTime() - 30 * 60 * 1000).toISOString();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+
+    // Fetch recent 10 events for this agent
+    const { data: recentEvents, error: eventsError } = await supabase
+      .from("events")
+      .select("event_type, payload, created_at")
+      .eq("agent_id", agentId)
+      .order("created_at", { ascending: false })
+      .limit(10);
+
+    if (eventsError) {
+      console.error("[api/agents/detail] Events error:", eventsError.message);
+      return NextResponse.json({ error: "Failed to fetch events" }, { status: 500 });
+    }
+
+    const events = recentEvents as Array<{ event_type: string; payload: unknown; created_at: string }> | null;
+
+    // Fetch today's events for stats
+    const { data: todayEventsRaw, error: todayError } = await supabase
+      .from("events")
+      .select("event_type, created_at")
+      .eq("agent_id", agentId)
+      .gte("created_at", todayStart);
+
+    if (todayError) {
+      console.error("[api/agents/detail] Today events error:", todayError.message);
+    }
+
+    const todayEvents = todayEventsRaw as Array<{ event_type: string; created_at: string }> | null;
+
+    // Fetch latest moment
+    const { data: momentsRaw, error: momentsError } = await supabase
+      .from("moments")
+      .select("content, created_at")
+      .eq("agent_id", agentId)
+      .order("created_at", { ascending: false })
+      .limit(1);
+
+    if (momentsError) {
+      console.error("[api/agents/detail] Moments error:", momentsError.message);
+    }
+
+    const moments = momentsRaw as Array<{ content: string; created_at: string }> | null;
+
+    // Determine status
+    let status: "online" | "idle" | "offline" = "offline";
+    const latestEvent = events?.[0];
+    if (latestEvent) {
+      if (latestEvent.created_at >= fiveMinAgo) {
+        status = "online";
+      } else if (latestEvent.created_at >= thirtyMinAgo) {
+        status = "idle";
+      }
+    }
+
+    // Extract current task from latest event
+    let currentTask = "";
+    if (status === "online" && latestEvent) {
+      currentTask = extractEventSummary(
+        latestEvent.event_type,
+        latestEvent.payload as Record<string, unknown> | null
+      );
+    }
+
+    // Calculate today stats
+    const todayStats = {
+      total: todayEvents?.length || 0,
+      byType: {} as Record<string, number>,
+    };
+    for (const ev of todayEvents || []) {
+      todayStats.byType[ev.event_type] = (todayStats.byType[ev.event_type] || 0) + 1;
+    }
+
+    // Format recent events
+    const formattedEvents = (events || []).map((ev) => ({
+      type: ev.event_type,
+      summary: extractEventSummary(ev.event_type, ev.payload as Record<string, unknown> | null),
+      time: formatTime(ev.created_at),
+    }));
+
+    // Format latest moment
+    const latestMoment = moments?.[0]
+      ? {
+          content: moments[0].content,
+          time: formatTime(moments[0].created_at),
+        }
+      : null;
+
+    // Get agent name and role
+    const agentInfo = AGENT_NAMES[agentId] || { name: agentId, role: "Agent" };
+
+    return NextResponse.json({
+      agent_id: agentId,
+      name: agentInfo.name,
+      role: agentInfo.role,
+      status,
+      currentTask,
+      todayStats,
+      recentEvents: formattedEvents,
+      latestMoment,
+    });
+  } catch (err) {
+    console.error("[api/agents/detail] Error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/game/AgentDetailPanel.tsx
+++ b/src/components/game/AgentDetailPanel.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface AgentDetail {
+  agent_id: string;
+  name: string;
+  role: string;
+  status: 'online' | 'idle' | 'offline';
+  currentTask: string;
+  todayStats: { total: number; byType: Record<string, number> };
+  recentEvents: Array<{ type: string; summary: string; time: string }>;
+  latestMoment: { content: string; time: string } | null;
+}
+
+interface AgentDetailPanelProps {
+  agentId: string | null;
+  onClose: () => void;
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'online': return '#00e436';
+    case 'idle': return '#ffec27';
+    default: return '#83769c';
+  }
+}
+
+function getStatusEmoji(status: string): string {
+  switch (status) {
+    case 'online': return '💻';
+    case 'idle': return '☕';
+    default: return '💤';
+  }
+}
+
+export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
+  const [detail, setDetail] = useState<AgentDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (!agentId) {
+      setIsVisible(false);
+      return;
+    }
+
+    setLoading(true);
+    fetch(`/api/agents/${agentId}/detail`)
+      .then((res) => res.json())
+      .then((data) => {
+        setDetail(data);
+        setIsVisible(true);
+      })
+      .catch((err) => console.error('Failed to fetch agent detail:', err))
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(onClose, 200);
+  };
+
+  if (!agentId) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/50 z-40 transition-opacity duration-200 ${
+          isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={handleClose}
+      />
+
+      {/* Slide-in Panel */}
+      <div
+        className={`fixed top-0 right-0 h-full w-80 max-w-[90vw] bg-[#1d2b53] border-l-4 border-[#5f574f] z-50 transform transition-transform duration-200 ease-out overflow-y-auto ${
+          isVisible ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {/* Header */}
+        <div className="sticky top-0 bg-[#29366f] border-b-2 border-[#5f574f] px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-xl">{detail ? getStatusEmoji(detail.status) : '👤'}</span>
+            <div>
+              <h2 className="font-pixel text-sm text-[#fff1e8]">
+                {loading ? '...' : detail?.name || agentId}
+              </h2>
+              <p className="font-pixel text-[8px] text-[#c2c3c7]">
+                {detail?.role || ''}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleClose}
+            className="font-pixel text-xs text-[#ff004d] hover:text-[#fff1e8] transition-colors px-2 py-1"
+            aria-label="Close panel"
+          >
+            [X]
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="p-4 text-center">
+            <span className="font-pixel text-xs text-[#c2c3c7] animate-pulse">Loading...</span>
+          </div>
+        ) : detail ? (
+          <div className="p-4 space-y-4">
+            {/* Status */}
+            <div className="flex items-center gap-2">
+              <span
+                className="w-2 h-2 rounded-full animate-pulse"
+                style={{ backgroundColor: getStatusColor(detail.status) }}
+              />
+              <span
+                className="font-pixel text-xs"
+                style={{ color: getStatusColor(detail.status) }}
+              >
+                {detail.status.toUpperCase()}
+              </span>
+            </div>
+
+            {/* Current Task */}
+            {detail.currentTask && (
+              <div className="bg-[#000]/30 border border-[#5f574f] p-3 rounded">
+                <div className="font-pixel text-[8px] text-[#c2c3c7] mb-1">当前任务</div>
+                <div className="font-pixel text-sm text-[#fff1e8] leading-relaxed">
+                  {detail.currentTask}
+                </div>
+              </div>
+            )}
+
+            {/* Today Stats */}
+            <div className="bg-[#000]/30 border border-[#5f574f] p-3 rounded">
+              <div className="font-pixel text-[8px] text-[#c2c3c7] mb-2">今日统计</div>
+              <div className="flex items-center gap-4">
+                <div>
+                  <div className="font-pixel text-lg text-[#29adff]">{detail.todayStats.total}</div>
+                  <div className="font-pixel text-[8px] text-[#83769c]">事件</div>
+                </div>
+                <div className="flex-1 flex flex-wrap gap-1">
+                  {Object.entries(detail.todayStats.byType).slice(0, 4).map(([type, count]) => (
+                    <span
+                      key={type}
+                      className="font-pixel text-[8px] text-[#c2c3c7] bg-[#5f574f]/30 px-1 py-0.5 rounded"
+                    >
+                      {type}: {count}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Recent Events */}
+            <div>
+              <div className="font-pixel text-[8px] text-[#c2c3c7] mb-2">最近动态</div>
+              <div className="space-y-2 max-h-48 overflow-y-auto">
+                {detail.recentEvents.length > 0 ? (
+                  detail.recentEvents.map((ev, i) => (
+                    <div
+                      key={i}
+                      className="bg-[#000]/20 border border-[#5f574f]/50 p-2 rounded"
+                    >
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="font-pixel text-[8px] text-[#ffa300]">{ev.type}</span>
+                        <span className="font-pixel text-[8px] text-[#83769c]">{ev.time}</span>
+                      </div>
+                      <div className="font-pixel text-[10px] text-[#c2c3c7] leading-relaxed break-words">
+                        {ev.summary}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="font-pixel text-[10px] text-[#83769c] text-center py-2">
+                    暂无动态
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Latest Moment */}
+            {detail.latestMoment && (
+              <div className="bg-[#29366f]/50 border border-[#5f574f] p-3 rounded">
+                <div className="font-pixel text-[8px] text-[#c2c3c7] mb-1 flex items-center gap-1">
+                  <span>📝</span> 最新朋友圈
+                  <span className="text-[#83769c] ml-auto">{detail.latestMoment.time}</span>
+                </div>
+                <div className="font-pixel text-[10px] text-[#fff1e8] leading-relaxed">
+                  {detail.latestMoment.content}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="p-4 text-center">
+            <span className="font-pixel text-xs text-[#ff004d]">加载失败</span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/game/TownCanvas.tsx
+++ b/src/components/game/TownCanvas.tsx
@@ -2,76 +2,8 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import Phaser from 'phaser';
-import type { AgentStatus } from '@/lib/types';
 import AgentListPanel from './AgentListPanel';
-
-function AgentDetailModal({ agent, onClose }: { agent: AgentStatus | null; onClose: () => void }) {
-  if (!agent) return null;
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'online': return '#00e436';
-      case 'idle': return '#ffec27';
-      default: return '#83769c';
-    }
-  };
-  const formatTimeAgo = (dateStr: string | null) => {
-    if (!dateStr) return 'Never';
-    const diffMs = Date.now() - new Date(dateStr).getTime();
-    const diffMin = Math.floor(diffMs / 60000);
-    if (diffMin < 60) return `${diffMin}m ago`;
-    return `${Math.floor(diffMin / 60)}h ago`;
-  };
-  const formatTaskTime = (dateStr: string | null) => {
-    if (!dateStr) return '';
-    return new Date(dateStr).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-  };
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/70" />
-      <div className="relative w-full max-w-sm mx-4" onClick={(e) => e.stopPropagation()}>
-        <div className="border-4 border-[#5f574f] bg-[#1d2b53] rounded-lg">
-          <div className="border-b-2 border-[#5f574f] bg-[#29366f] px-4 py-3 flex justify-between rounded-t-lg">
-            <h2 className="font-pixel text-sm text-[#fff1e8] truncate">{agent.agent_id}</h2>
-            <button onClick={onClose} className="font-pixel text-xs text-[#ff004d]">[X]</button>
-          </div>
-          <div className="p-4 space-y-3">
-            <div className="flex items-center gap-3">
-              <span className="font-pixel text-[10px] text-[#c2c3c7]">STATUS:</span>
-              <span className="font-pixel text-xs" style={{ color: getStatusColor(agent.status) }}>
-                {agent.status.toUpperCase()}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="font-pixel text-[10px] text-[#c2c3c7]">DOING:</span>
-              <span className="font-pixel text-xs text-[#fff1e8]">
-                {agent.current_task?.description || (agent.status === 'online' ? 'Working' : 'Resting')}
-              </span>
-            </div>
-            {agent.current_task?.started_at && (
-              <div className="flex items-center gap-3">
-                <span className="font-pixel text-[10px] text-[#c2c3c7]">STARTED:</span>
-                <span className="font-pixel text-xs text-[#29adff]">{formatTaskTime(agent.current_task.started_at)}</span>
-              </div>
-            )}
-            <div className="flex items-center gap-3">
-              <span className="font-pixel text-[10px] text-[#c2c3c7]">LAST:</span>
-              <span className="font-pixel text-xs text-[#fff1e8]">{formatTimeAgo(agent.last_event_at)}</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="font-pixel text-[10px] text-[#c2c3c7]">24H EVENTS:</span>
-              <span className="font-pixel text-xs text-[#29adff]">{agent.event_count_24h}</span>
-            </div>
-          </div>
-          <div className="border-t-2 border-[#5f574f] px-4 py-3">
-            <button onClick={onClose} className="w-full font-pixel text-xs text-[#c2c3c7] border-2 border-[#5f574f] py-2 hover:bg-[#5f574f]/20">
-              CLOSE
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { AgentDetailPanel } from './AgentDetailPanel';
 
 interface TownCanvasProps {
   initialArea?: string;
@@ -80,18 +12,10 @@ interface TownCanvasProps {
 export default function TownCanvas({ initialArea }: TownCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
-  const [selectedAgent, setSelectedAgent] = useState<AgentStatus | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
-  const handleAgentClick = useCallback(async (agentId: string) => {
-    try {
-      const res = await fetch('/api/agents');
-      if (!res.ok) return;
-      const agents: AgentStatus[] = await res.json();
-      const agent = agents.find(a => a.agent_id === agentId);
-      if (agent) setSelectedAgent(agent);
-    } catch (err) {
-      console.error('Failed to fetch agent details:', err);
-    }
+  const handleAgentClick = useCallback((agentId: string) => {
+    setSelectedAgentId(agentId);
   }, []);
 
   useEffect(() => {
@@ -149,9 +73,9 @@ export default function TownCanvas({ initialArea }: TownCanvasProps) {
     if (scene?.focusOnAgent) {
       scene.focusOnAgent(agentId);
     }
-    // Also fetch and show details
-    handleAgentClick(agentId);
-  }, [handleAgentClick]);
+    // Show detail panel
+    setSelectedAgentId(agentId);
+  }, []);
 
   return (
     <>
@@ -161,9 +85,9 @@ export default function TownCanvas({ initialArea }: TownCanvasProps) {
         className="w-full h-full"
       />
       <AgentListPanel onAgentSelect={handleAgentSelect} />
-      <AgentDetailModal
-        agent={selectedAgent}
-        onClose={() => setSelectedAgent(null)}
+      <AgentDetailPanel
+        agentId={selectedAgentId}
+        onClose={() => setSelectedAgentId(null)}
       />
     </>
   );


### PR DESCRIPTION
## Summary
点击 Town 中的 Agent sprite，弹出详情面板，展示实时状态和工作摘要。

## Changes
- **API**: `/api/agents/[id]/detail` - 获取 agent 详情（中文名、角色、状态、今日统计、最近事件、最新朋友圈）
- **Component**: `AgentDetailPanel.tsx` - 右侧滑出面板，暗色像素风格
- **Integration**: TownCanvas 点击 agent 触发面板

## Agent 名称映射
| ID | 中文名 | 角色 |
|----|--------|------|
| secretary | 刘亦菲 | 首席秘书官 |
| cto | 扫地僧 | 首席技术官 |
| dev-lead | 韦小宝 | 研发主管 |
| cpo | 乔布斯 | 首席产品官 |
| uiux | 高圆圆 | UI/UX 设计师 |
| cmo | 达达里奥 | 首席营销官 |
| culture | 李子柒 | 文化顾问 |
| hardware | 马斯克 | 硬件专家 |
| advisor | 巴菲特 | 战略顾问 |

Closes #52