### PR TITLE
feat: OpenClaw 控制面板 (closes #75)

### DIFF
--- a/src/app/api/gateway/actions/route.ts
+++ b/src/app/api/gateway/actions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { restartGateway, updateOpenClaw } from "@/lib/openclaw-gateway";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/gateway/actions
+ * 
+ * Perform gateway operations:
+ * - restart: Restart the gateway service
+ * - update: Update OpenClaw to latest version
+ * 
+ * These are potentially dangerous operations and should be
+ * protected by confirmation dialogs on the frontend.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { action, confirmToken } = body;
+
+    // Validate action
+    if (!action || !["restart", "update"].includes(action)) {
+      return NextResponse.json(
+        { error: "Invalid action. Must be 'restart' or 'update'" },
+        { status: 400 }
+      );
+    }
+
+    // Validate confirmation token (simple security measure)
+    // In production, this should be a proper CSRF token or similar
+    if (!confirmToken || confirmToken !== "CONFIRM_GATEWAY_ACTION") {
+      return NextResponse.json(
+        { error: "Missing or invalid confirmation token" },
+        { status: 403 }
+      );
+    }
+
+    let result;
+    switch (action) {
+      case "restart":
+        result = await restartGateway();
+        break;
+      case "update":
+        result = await updateOpenClaw();
+        break;
+      default:
+        return NextResponse.json(
+          { error: "Unknown action" },
+          { status: 400 }
+        );
+    }
+
+    return NextResponse.json({
+      action,
+      result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error("[api/gateway/actions] Error:", err);
+    return NextResponse.json(
+      { error: "Failed to perform gateway action" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/gateway/route.ts
+++ b/src/app/api/gateway/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { getGatewayStatus, checkForUpdates, getRecentLogs } from "@/lib/openclaw-gateway";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/gateway
+ * 
+ * Returns the current OpenClaw Gateway status including:
+ * - Running state and PID
+ * - Version information
+ * - Connected agents count
+ * - Channel status
+ * - Recent warnings
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const includeUpdates = searchParams.get("updates") === "true";
+    const includeLogs = searchParams.get("logs") === "true";
+    const logLines = parseInt(searchParams.get("logLines") || "50", 10);
+
+    // Get gateway status
+    const status = await getGatewayStatus();
+
+    // Optionally check for updates
+    let updateStatus = null;
+    if (includeUpdates) {
+      updateStatus = await checkForUpdates();
+    }
+
+    // Optionally get recent logs
+    let logs = null;
+    if (includeLogs) {
+      const logResult = await getRecentLogs(logLines);
+      logs = logResult;
+    }
+
+    return NextResponse.json({
+      status,
+      updateStatus,
+      logs,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error("[api/gateway] Error:", err);
+    return NextResponse.json(
+      { error: "Failed to get gateway status" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,45 @@
+import { getLocale, getTranslations } from "next-intl/server";
+import { Header } from "@/components/layout/Header";
+import { GatewayControlPanel } from "@/components/gateway";
+import { type Locale } from "@/i18n";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  const locale = (await getLocale()) as Locale;
+  const t = await getTranslations("settings");
+
+  return (
+    <div className="min-h-screen bg-[#1a1c2c]">
+      <Header
+        title={t("title")}
+        subtitle={t("subtitle")}
+        icon="⚙️"
+        currentPage="home"
+        locale={locale}
+      />
+
+      <main className="mx-auto max-w-3xl px-4 py-6 space-y-6">
+        {/* Gateway Control Panel */}
+        <section>
+          <h2 className="font-pixel text-sm text-[#fff1e8] mb-3">
+            {t("gateway.title")}
+          </h2>
+          <GatewayControlPanel />
+        </section>
+
+        {/* Future: Configuration Management */}
+        <section className="opacity-50">
+          <h2 className="font-pixel text-sm text-[#fff1e8] mb-3">
+            {t("config.title")}
+          </h2>
+          <div className="bg-[#1d2b53] rounded-lg border-2 border-[#5f574f] p-4">
+            <p className="font-pixel text-[10px] text-[#83769c]">
+              {t("config.comingSoon")}
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/gateway/GatewayPanel.tsx
+++ b/src/components/gateway/GatewayPanel.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useGatewayStatus, useGatewayActions } from "@/lib/hooks";
+
+/**
+ * Gateway Status Indicator
+ * 
+ * A small indicator showing Gateway online/offline status.
+ * Clicking it navigates to the settings page.
+ */
+export function GatewayStatusIndicator() {
+  const { data, loading } = useGatewayStatus({ pollInterval: 30000 });
+
+  const isOnline = data?.status?.running ?? false;
+
+  return (
+    <Link
+      href="/settings"
+      className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-[#1d2b53]/50 cursor-pointer hover:bg-[#1d2b53]/70 transition-colors"
+      title={isOnline ? "Gateway 运行中 - 点击查看详情" : "Gateway 离线 - 点击查看详情"}
+    >
+      <span
+        className={`w-2 h-2 rounded-full ${
+          loading
+            ? "bg-yellow-400 animate-pulse"
+            : isOnline
+            ? "bg-green-400"
+            : "bg-red-400"
+        }`}
+      />
+      <span className="font-pixel text-[9px] text-[#c2c3c7] hidden sm:inline">
+        {loading ? "..." : isOnline ? "在线" : "离线"}
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * Gateway Control Panel
+ * 
+ * Full control panel for managing the OpenClaw Gateway.
+ */
+export function GatewayControlPanel() {
+  const { data, loading, error, refresh } = useGatewayStatus({
+    includeUpdates: true,
+    includeLogs: false,
+    pollInterval: 30000,
+  });
+  const { restart, update, loading: actionLoading } = useGatewayActions();
+
+  const [showConfirm, setShowConfirm] = useState<"restart" | "update" | null>(null);
+  const [actionResult, setActionResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const handleRestart = async () => {
+    setShowConfirm(null);
+    const result = await restart();
+    setActionResult(result);
+    if (result.success) {
+      setTimeout(refresh, 3000); // Refresh after restart
+    }
+  };
+
+  const handleUpdate = async () => {
+    setShowConfirm(null);
+    const result = await update();
+    setActionResult(result);
+    if (result.success) {
+      setTimeout(refresh, 5000); // Refresh after update
+    }
+  };
+
+  const status = data?.status;
+  const updateStatus = data?.updateStatus;
+
+  return (
+    <div className="bg-[#1d2b53] rounded-lg border-2 border-[#5f574f] p-4 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="font-pixel text-sm text-[#fff1e8] flex items-center gap-2">
+          <span>🦞</span>
+          <span>OpenClaw Gateway</span>
+        </h2>
+        <button
+          onClick={refresh}
+          disabled={loading}
+          className="font-pixel text-[9px] text-[#83769c] hover:text-[#fff1e8] transition-colors disabled:opacity-50"
+        >
+          {loading ? "刷新中..." : "刷新"}
+        </button>
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-900/30 border border-red-500/50 rounded px-3 py-2">
+          <p className="font-pixel text-[10px] text-red-400">{error}</p>
+        </div>
+      )}
+
+      {/* Status Section */}
+      {status && (
+        <div className="space-y-3">
+          {/* Running Status */}
+          <div className="flex items-center gap-3">
+            <span
+              className={`w-3 h-3 rounded-full ${
+                status.running ? "bg-green-400" : "bg-red-400"
+              }`}
+            />
+            <span className="font-pixel text-xs text-[#fff1e8]">
+              {status.running ? "运行中" : "已停止"}
+            </span>
+            {status.pid && (
+              <span className="font-pixel text-[9px] text-[#83769c]">
+                PID: {status.pid}
+              </span>
+            )}
+          </div>
+
+          {/* Version & Uptime */}
+          <div className="grid grid-cols-2 gap-2 text-[10px]">
+            <div>
+              <span className="font-pixel text-[#83769c]">版本: </span>
+              <span className="font-pixel text-[#fff1e8]">{status.version || "未知"}</span>
+            </div>
+            <div>
+              <span className="font-pixel text-[#83769c]">状态: </span>
+              <span className="font-pixel text-[#fff1e8]">{status.uptime || "未知"}</span>
+            </div>
+            <div>
+              <span className="font-pixel text-[#83769c]">端口: </span>
+              <span className="font-pixel text-[#fff1e8]">{status.port || "未知"}</span>
+            </div>
+            <div>
+              <span className="font-pixel text-[#83769c]">绑定: </span>
+              <span className="font-pixel text-[#fff1e8]">{status.bind || "未知"}</span>
+            </div>
+          </div>
+
+          {/* Agent Count */}
+          <div className="flex items-center gap-2">
+            <span className="font-pixel text-[10px] text-[#83769c]">已连接 Agent:</span>
+            <span className="font-pixel text-xs text-[#ffa300]">{status.agentCount}</span>
+          </div>
+
+          {/* Channels */}
+          {status.channels.length > 0 && (
+            <div className="space-y-1">
+              <span className="font-pixel text-[10px] text-[#83769c]">频道状态:</span>
+              <div className="flex flex-wrap gap-2">
+                {status.channels.map((channel) => (
+                  <div
+                    key={channel.id}
+                    className={`px-2 py-1 rounded text-[9px] font-pixel ${
+                      channel.configured
+                        ? "bg-green-900/30 text-green-400"
+                        : "bg-gray-900/30 text-gray-400"
+                    }`}
+                  >
+                    {channel.name}
+                    {channel.accountCount > 1 && ` (${channel.accountCount})`}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Warnings */}
+          {status.warnings.length > 0 && (
+            <div className="bg-yellow-900/20 border border-yellow-500/30 rounded px-3 py-2">
+              <p className="font-pixel text-[9px] text-yellow-400 mb-1">⚠️ 警告</p>
+              {status.warnings.map((warning, i) => (
+                <p key={i} className="font-pixel text-[9px] text-yellow-300/80">
+                  {warning}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Dashboard Link */}
+          {status.dashboardUrl && (
+            <a
+              href={status.dashboardUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block font-pixel text-[10px] text-[#7ec8e3] hover:text-[#fff1e8] underline"
+            >
+              打开控制台 →
+            </a>
+          )}
+        </div>
+      )}
+
+      {/* Update Status */}
+      {updateStatus && (
+        <div className="border-t border-[#5f574f] pt-3">
+          <div className="flex items-center justify-between">
+            <span className="font-pixel text-[10px] text-[#83769c]">
+              当前版本: {updateStatus.currentVersion}
+            </span>
+            {updateStatus.updateAvailable && (
+              <span className="font-pixel text-[9px] text-green-400">
+                新版本可用: {updateStatus.latestVersion}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className="flex gap-2 pt-2 border-t border-[#5f574f]">
+        <button
+          onClick={() => setShowConfirm("restart")}
+          disabled={actionLoading || !status?.running}
+          className="flex-1 font-pixel text-[10px] px-3 py-2 bg-[#ff6b6b]/20 text-[#ff6b6b] rounded border border-[#ff6b6b]/30 hover:bg-[#ff6b6b]/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          🔄 重启
+        </button>
+        <button
+          onClick={() => setShowConfirm("update")}
+          disabled={actionLoading || !updateStatus?.updateAvailable}
+          className="flex-1 font-pixel text-[10px] px-3 py-2 bg-[#4ecdc4]/20 text-[#4ecdc4] rounded border border-[#4ecdc4]/30 hover:bg-[#4ecdc4]/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          ⬆️ 升级
+        </button>
+      </div>
+
+      {/* Action Result */}
+      {actionResult && (
+        <div
+          className={`rounded px-3 py-2 ${
+            actionResult.success
+              ? "bg-green-900/30 border border-green-500/50"
+              : "bg-red-900/30 border border-red-500/50"
+          }`}
+        >
+          <p
+            className={`font-pixel text-[10px] ${
+              actionResult.success ? "text-green-400" : "text-red-400"
+            }`}
+          >
+            {actionResult.message}
+          </p>
+        </div>
+      )}
+
+      {/* Confirmation Dialog */}
+      {showConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-[#1d2b53] border-2 border-[#5f574f] rounded-lg p-4 max-w-sm mx-4">
+            <h3 className="font-pixel text-sm text-[#fff1e8] mb-3">
+              {showConfirm === "restart" ? "确认重启?" : "确认升级?"}
+            </h3>
+            <p className="font-pixel text-[10px] text-[#c2c3c7] mb-4">
+              {showConfirm === "restart"
+                ? "重启 Gateway 会暂时中断所有 Agent 连接。确定要继续吗？"
+                : "升级 OpenClaw 可能需要几分钟时间，期间服务会暂时不可用。确定要继续吗？"}
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowConfirm(null)}
+                className="flex-1 font-pixel text-[10px] px-3 py-2 bg-[#5f574f]/50 text-[#c2c3c7] rounded hover:bg-[#5f574f]/70 transition-colors"
+              >
+                取消
+              </button>
+              <button
+                onClick={showConfirm === "restart" ? handleRestart : handleUpdate}
+                className="flex-1 font-pixel text-[10px] px-3 py-2 bg-[#ff6b6b]/30 text-[#ff6b6b] rounded hover:bg-[#ff6b6b]/50 transition-colors"
+              >
+                确认
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/gateway/index.ts
+++ b/src/components/gateway/index.ts
@@ -1,0 +1,1 @@
+export { GatewayStatusIndicator, GatewayControlPanel } from "./GatewayPanel";

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { NotificationBell } from "@/components/notifications";
 import { LanguageSwitcher } from "@/components/i18n";
 import { WorkspaceSelector } from "@/components/workspace";
+import { GatewayStatusIndicator } from "@/components/gateway";
 import { type Locale } from "@/i18n";
 
 interface HeaderProps {
@@ -43,6 +44,7 @@ export function Header({ title, subtitle, icon, currentPage, locale }: HeaderPro
             </div>
           </div>
           <div className="flex items-center gap-2 sm:gap-4">
+            <GatewayStatusIndicator />
             <WorkspaceSelector />
             <LanguageSwitcher currentLocale={locale} variant="buttons" />
             <NotificationBell />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -84,8 +84,16 @@
   },
   "settings": {
     "title": "Settings",
+    "subtitle": "System Configuration",
     "language": "Language",
-    "languageDescription": "Choose your preferred language"
+    "languageDescription": "Choose your preferred language",
+    "gateway": {
+      "title": "OpenClaw Gateway"
+    },
+    "config": {
+      "title": "Configuration",
+      "comingSoon": "Configuration management coming soon..."
+    }
   },
   "replay": {
     "title": "AGENT TOWN",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -84,8 +84,16 @@
   },
   "settings": {
     "title": "设置",
+    "subtitle": "系统配置",
     "language": "语言",
-    "languageDescription": "选择你偏好的语言"
+    "languageDescription": "选择你偏好的语言",
+    "gateway": {
+      "title": "OpenClaw Gateway"
+    },
+    "config": {
+      "title": "配置管理",
+      "comingSoon": "配置管理功能即将推出..."
+    }
   },
   "replay": {
     "title": "AGENT TOWN",

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,0 +1,8 @@
+export { useGatewayStatus, useGatewayActions } from "./useGatewayStatus";
+export type {
+  GatewayStatus,
+  GatewayAgent,
+  GatewayChannel,
+  UpdateStatus,
+  GatewayData,
+} from "./useGatewayStatus";

--- a/src/lib/hooks/useGatewayStatus.ts
+++ b/src/lib/hooks/useGatewayStatus.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface GatewayStatus {
+  running: boolean;
+  pid: number | null;
+  version: string | null;
+  uptime: string | null;
+  uptimeMs: number | null;
+  port: number | null;
+  bind: string | null;
+  dashboardUrl: string | null;
+  serviceFile: string | null;
+  configPath: string | null;
+  logPath: string | null;
+  agentCount: number;
+  agents: GatewayAgent[];
+  channels: GatewayChannel[];
+  warnings: string[];
+  error: string | null;
+}
+
+export interface GatewayAgent {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  sessionCount: number;
+  lastActivity: string | null;
+}
+
+export interface GatewayChannel {
+  id: string;
+  name: string;
+  configured: boolean;
+  running: boolean;
+  accountCount: number;
+}
+
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  channel: string;
+  error: string | null;
+}
+
+export interface GatewayData {
+  status: GatewayStatus | null;
+  updateStatus: UpdateStatus | null;
+  logs: { logs: string; error: string | null } | null;
+  timestamp: string | null;
+}
+
+interface UseGatewayStatusOptions {
+  includeUpdates?: boolean;
+  includeLogs?: boolean;
+  logLines?: number;
+  pollInterval?: number; // in milliseconds, 0 to disable
+}
+
+export function useGatewayStatus(options: UseGatewayStatusOptions = {}) {
+  const {
+    includeUpdates = false,
+    includeLogs = false,
+    logLines = 50,
+    pollInterval = 30000, // 30 seconds default
+  } = options;
+
+  const [data, setData] = useState<GatewayData>({
+    status: null,
+    updateStatus: null,
+    logs: null,
+    timestamp: null,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (includeUpdates) params.set("updates", "true");
+      if (includeLogs) {
+        params.set("logs", "true");
+        params.set("logLines", String(logLines));
+      }
+
+      const response = await fetch(`/api/gateway?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const result = await response.json();
+      setData(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "获取状态失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [includeUpdates, includeLogs, logLines]);
+
+  useEffect(() => {
+    fetchStatus();
+
+    if (pollInterval > 0) {
+      const interval = setInterval(fetchStatus, pollInterval);
+      return () => clearInterval(interval);
+    }
+  }, [fetchStatus, pollInterval]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    return fetchStatus();
+  }, [fetchStatus]);
+
+  return { data, loading, error, refresh };
+}
+
+interface ActionResult {
+  success: boolean;
+  message: string;
+  error: string | null;
+}
+
+export function useGatewayActions() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const performAction = useCallback(async (action: "restart" | "update"): Promise<ActionResult> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/gateway/actions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action,
+          confirmToken: "CONFIRM_GATEWAY_ACTION",
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "操作失败";
+      setError(message);
+      return { success: false, message: "操作失败", error: message };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const restart = useCallback(() => performAction("restart"), [performAction]);
+  const update = useCallback(() => performAction("update"), [performAction]);
+
+  return { restart, update, loading, error };
+}

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,0 +1,410 @@
+/**
+ * OpenClaw Gateway Integration
+ *
+ * Provides functions to interact with the OpenClaw Gateway CLI
+ * for status monitoring, restart, and update operations.
+ */
+
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+// Timeout for CLI commands (30 seconds)
+const CLI_TIMEOUT = 30_000;
+
+export interface GatewayStatus {
+  running: boolean;
+  pid: number | null;
+  version: string | null;
+  uptime: string | null;
+  uptimeMs: number | null;
+  port: number | null;
+  bind: string | null;
+  dashboardUrl: string | null;
+  serviceFile: string | null;
+  configPath: string | null;
+  logPath: string | null;
+  agentCount: number;
+  agents: GatewayAgent[];
+  channels: GatewayChannel[];
+  warnings: string[];
+  error: string | null;
+}
+
+export interface GatewayAgent {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  sessionCount: number;
+  lastActivity: string | null;
+}
+
+export interface GatewayChannel {
+  id: string;
+  name: string;
+  configured: boolean;
+  running: boolean;
+  accountCount: number;
+}
+
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  channel: string;
+  error: string | null;
+}
+
+export interface OperationResult {
+  success: boolean;
+  message: string;
+  error: string | null;
+}
+
+/**
+ * Parse uptime from service status output.
+ */
+function parseUptime(statusOutput: string): { uptime: string | null; uptimeMs: number | null } {
+  // Look for "Runtime: running (pid XXXX, state active, sub running, last exit 0, reason 0)"
+  const runtimeMatch = statusOutput.match(/Runtime:\s*running\s*\(pid\s*(\d+)/);
+  if (!runtimeMatch) {
+    return { uptime: null, uptimeMs: null };
+  }
+
+  // Try to extract uptime from systemd status
+  // This is a simplified approach - actual uptime would need systemd query
+  return { uptime: "运行中", uptimeMs: null };
+}
+
+/**
+ * Parse gateway status from CLI output.
+ */
+function parseGatewayStatus(statusOutput: string, healthOutput: string | null): GatewayStatus {
+  const status: GatewayStatus = {
+    running: false,
+    pid: null,
+    version: null,
+    uptime: null,
+    uptimeMs: null,
+    port: null,
+    bind: null,
+    dashboardUrl: null,
+    serviceFile: null,
+    configPath: null,
+    logPath: null,
+    agentCount: 0,
+    agents: [],
+    channels: [],
+    warnings: [],
+    error: null,
+  };
+
+  // Parse running status
+  const runtimeMatch = statusOutput.match(/Runtime:\s*running\s*\(pid\s*(\d+)/);
+  if (runtimeMatch) {
+    status.running = true;
+    status.pid = parseInt(runtimeMatch[1], 10);
+  }
+
+  // Parse version from output
+  const versionMatch = statusOutput.match(/OpenClaw\s+([\d.]+)/);
+  if (versionMatch) {
+    status.version = versionMatch[1];
+  }
+
+  // Parse port
+  const portMatch = statusOutput.match(/port[=:]\s*(\d+)/i);
+  if (portMatch) {
+    status.port = parseInt(portMatch[1], 10);
+  }
+
+  // Parse bind mode
+  const bindMatch = statusOutput.match(/bind[=:]\s*(\w+)/i);
+  if (bindMatch) {
+    status.bind = bindMatch[1];
+  }
+
+  // Parse dashboard URL
+  const dashboardMatch = statusOutput.match(/Dashboard:\s*(https?:\/\/[^\s]+)/);
+  if (dashboardMatch) {
+    status.dashboardUrl = dashboardMatch[1];
+  }
+
+  // Parse service file
+  const serviceMatch = statusOutput.match(/Service file:\s*([^\n]+)/);
+  if (serviceMatch) {
+    status.serviceFile = serviceMatch[1].trim();
+  }
+
+  // Parse config path
+  const configMatch = statusOutput.match(/Config \(cli\):\s*([^\n]+)/);
+  if (configMatch) {
+    status.configPath = configMatch[1].trim();
+  }
+
+  // Parse log path
+  const logMatch = statusOutput.match(/File logs:\s*([^\n]+)/);
+  if (logMatch) {
+    status.logPath = logMatch[1].trim();
+  }
+
+  // Parse warnings
+  const warningMatches = statusOutput.matchAll(/[-•]\s*([^\n]+(?:channels\.[^\n]+|groupPolicy[^\n]+))/g);
+  for (const match of warningMatches) {
+    status.warnings.push(match[1].trim());
+  }
+
+  // Parse health data if available
+  if (healthOutput) {
+    try {
+      // Extract JSON from health output (skip any prefix text)
+      const jsonStart = healthOutput.indexOf("{");
+      if (jsonStart >= 0) {
+        const healthData = JSON.parse(healthOutput.slice(jsonStart));
+        
+        // Parse agents
+        if (healthData.agents && Array.isArray(healthData.agents)) {
+          status.agents = healthData.agents.map((agent: Record<string, unknown>) => ({
+            id: agent.agentId as string,
+            name: (agent.name as string) || (agent.agentId as string),
+            isDefault: agent.isDefault as boolean || false,
+            sessionCount: (agent.sessions as { count?: number })?.count || 0,
+            lastActivity: null,
+          }));
+          status.agentCount = status.agents.length;
+        }
+
+        // Parse channels
+        if (healthData.channels && typeof healthData.channels === "object") {
+          const channelLabels = healthData.channelLabels as Record<string, string> || {};
+          for (const [channelId, channelData] of Object.entries(healthData.channels)) {
+            const data = channelData as Record<string, unknown>;
+            const accounts = data.accounts as Record<string, unknown> || {};
+            status.channels.push({
+              id: channelId,
+              name: channelLabels[channelId] || channelId,
+              configured: data.configured as boolean || false,
+              running: data.running as boolean || false,
+              accountCount: Object.keys(accounts).length,
+            });
+          }
+        }
+      }
+    } catch {
+      // Health parsing failed, continue with basic status
+    }
+  }
+
+  // Parse uptime
+  const uptimeInfo = parseUptime(statusOutput);
+  status.uptime = uptimeInfo.uptime;
+  status.uptimeMs = uptimeInfo.uptimeMs;
+
+  return status;
+}
+
+/**
+ * Get OpenClaw Gateway status.
+ */
+export async function getGatewayStatus(): Promise<GatewayStatus> {
+  try {
+    // Run gateway status command
+    const { stdout: statusOutput } = await execAsync("openclaw gateway status 2>&1", {
+      timeout: CLI_TIMEOUT,
+    });
+
+    // Try to get health data
+    let healthOutput: string | null = null;
+    try {
+      const { stdout } = await execAsync("openclaw gateway call health 2>&1", {
+        timeout: CLI_TIMEOUT,
+      });
+      healthOutput = stdout;
+    } catch {
+      // Health call failed, continue without it
+    }
+
+    return parseGatewayStatus(statusOutput, healthOutput);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      running: false,
+      pid: null,
+      version: null,
+      uptime: null,
+      uptimeMs: null,
+      port: null,
+      bind: null,
+      dashboardUrl: null,
+      serviceFile: null,
+      configPath: null,
+      logPath: null,
+      agentCount: 0,
+      agents: [],
+      channels: [],
+      warnings: [],
+      error: `获取状态失败: ${error}`,
+    };
+  }
+}
+
+/**
+ * Get OpenClaw version.
+ */
+export async function getVersion(): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync("openclaw --version 2>&1", {
+      timeout: CLI_TIMEOUT,
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check for updates.
+ */
+export async function checkForUpdates(): Promise<UpdateStatus> {
+  try {
+    const { stdout } = await execAsync("openclaw update status --json 2>&1", {
+      timeout: CLI_TIMEOUT,
+    });
+
+    // Try to parse JSON output
+    const jsonStart = stdout.indexOf("{");
+    if (jsonStart >= 0) {
+      const data = JSON.parse(stdout.slice(jsonStart));
+      return {
+        currentVersion: data.currentVersion || data.installed || "unknown",
+        latestVersion: data.latestVersion || data.latest || null,
+        updateAvailable: data.updateAvailable || data.hasUpdate || false,
+        channel: data.channel || "stable",
+        error: null,
+      };
+    }
+
+    // Fallback: parse text output
+    const currentMatch = stdout.match(/(?:current|installed)[:\s]+([\d.]+)/i);
+    const latestMatch = stdout.match(/(?:latest|available)[:\s]+([\d.]+)/i);
+    
+    return {
+      currentVersion: currentMatch?.[1] || "unknown",
+      latestVersion: latestMatch?.[1] || null,
+      updateAvailable: latestMatch ? latestMatch[1] !== currentMatch?.[1] : false,
+      channel: "stable",
+      error: null,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      currentVersion: "unknown",
+      latestVersion: null,
+      updateAvailable: false,
+      channel: "stable",
+      error: `检查更新失败: ${error}`,
+    };
+  }
+}
+
+/**
+ * Restart the Gateway.
+ * This is a potentially dangerous operation and should require confirmation.
+ */
+export async function restartGateway(): Promise<OperationResult> {
+  try {
+    const { stdout, stderr } = await execAsync("openclaw gateway restart 2>&1", {
+      timeout: 60_000, // 60 seconds for restart
+    });
+
+    const output = stdout + stderr;
+    
+    // Check if restart was successful
+    if (output.includes("error") || output.includes("failed")) {
+      return {
+        success: false,
+        message: "重启失败",
+        error: output,
+      };
+    }
+
+    return {
+      success: true,
+      message: "Gateway 已重启",
+      error: null,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      message: "重启失败",
+      error,
+    };
+  }
+}
+
+/**
+ * Update OpenClaw to the latest version.
+ * This is a potentially dangerous operation and should require confirmation.
+ */
+export async function updateOpenClaw(): Promise<OperationResult> {
+  try {
+    const { stdout, stderr } = await execAsync("openclaw update --yes 2>&1", {
+      timeout: 300_000, // 5 minutes for update
+    });
+
+    const output = stdout + stderr;
+    
+    // Check if update was successful
+    if (output.includes("error") || output.includes("failed")) {
+      return {
+        success: false,
+        message: "升级失败",
+        error: output,
+      };
+    }
+
+    return {
+      success: true,
+      message: "OpenClaw 已升级到最新版本",
+      error: null,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      message: "升级失败",
+      error,
+    };
+  }
+}
+
+/**
+ * Get recent log entries.
+ */
+export async function getRecentLogs(lines: number = 50): Promise<{ logs: string; error: string | null }> {
+  try {
+    // First get the log path from status
+    const { stdout: statusOutput } = await execAsync("openclaw gateway status 2>&1", {
+      timeout: CLI_TIMEOUT,
+    });
+
+    const logMatch = statusOutput.match(/File logs:\s*([^\n]+)/);
+    if (!logMatch) {
+      return { logs: "", error: "无法获取日志路径" };
+    }
+
+    const logPath = logMatch[1].trim();
+    
+    // Read last N lines from log file
+    const { stdout } = await execAsync(`tail -n ${lines} "${logPath}" 2>&1`, {
+      timeout: CLI_TIMEOUT,
+    });
+
+    return { logs: stdout, error: null };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { logs: "", error: `获取日志失败: ${error}` };
+  }
+}


### PR DESCRIPTION
## 关联 Issue
Closes #75

## 改动概述
在 Agent Town 中添加 OpenClaw Gateway 控制面板功能：

### 状态监控
- 导航栏添加 Gateway 状态指示灯（绿色=在线，红色=离线）
- 点击指示灯跳转到 /settings 页面查看详情
- 显示 Gateway 版本、运行状态、PID
- 显示已连接的 Agent 数量
- 显示各频道（Discord/Feishu/QQ 等）配置状态
- 显示 Gateway 警告信息
- 提供 OpenClaw Dashboard 链接

### 操作能力
- 一键重启 Gateway（带二次确认）
- 检查更新并一键升级（带二次确认）
- 30 秒自动刷新状态

### 技术实现
- `src/lib/openclaw-gateway.ts`: 封装 OpenClaw CLI 调用
- `src/lib/hooks/useGatewayStatus.ts`: React Hook 管理状态
- `src/app/api/gateway/route.ts`: 状态查询 API
- `src/app/api/gateway/actions/route.ts`: 操作执行 API
- `src/components/gateway/GatewayPanel.tsx`: UI 组件
- `src/app/settings/page.tsx`: 设置页面

## 自测结果
- [x] 代码符合 Issue 验收标准
- [x] 状态监控功能完整
- [x] 重启/升级操作带确认对话框
- [x] i18n 支持（中英文）

## Review 重点
- API 安全性：操作需要 confirmToken
- CLI 调用超时处理
- 错误状态展示

## 架构约束符合性
- 使用 OpenClaw CLI 命令（`openclaw gateway status`、`openclaw gateway restart`、`openclaw update`）
- 遵循项目现有代码风格（Next.js App Router、Tailwind CSS、像素风 UI）